### PR TITLE
Adds ability to change retro owners.

### DIFF
--- a/api/app/admin/retros.rb
+++ b/api/app/admin/retros.rb
@@ -41,7 +41,7 @@ ActiveAdmin.register Retro do
   filter :created_at
   filter :updated_at
   filter :is_private, :label => 'Private'
-
+  
   index do
     column('ID', sortable: :id) { |retro| link_to "#{retro.id} ", admin_retro_path(retro) }
     column('Name', :name)
@@ -130,6 +130,7 @@ ActiveAdmin.register Retro do
       f.input :name
       f.input :slug
       f.input :video_link
+      f.input :owner_email, label: 'Owner Email'
     end
     f.inputs do
       if f.object.encrypted_password?
@@ -148,7 +149,17 @@ ActiveAdmin.register Retro do
       @retro = Retro.friendly.find(params.fetch(:id))
     end
 
+    def find_user_by_email(owner_email)
+      User.find_by_email(owner_email)
+    end
+
     def update
+      new_owner = find_user_by_email(params['retro']['owner_email'])
+
+
+      redirect_to edit_admin_retro_path(@retro), flash: {error: 'Could not change owners. User not found by email.'} and return unless new_owner
+      @retro.user = new_owner
+
       if params['retro']['remove_password'] && params['retro']['remove_password'][1] == 'Remove'
         params[:retro][:encrypted_password] = nil
       end

--- a/api/app/models/retro.rb
+++ b/api/app/models/retro.rb
@@ -76,6 +76,10 @@ class Retro < ActiveRecord::Base
     end
   end
 
+  def owner_email
+    user.email
+  end
+
   private
 
   def generate_slug

--- a/api/db/seeds.rb
+++ b/api/db/seeds.rb
@@ -49,12 +49,24 @@ User.find_or_create_by!(
 )
 
 alda = User.find_or_create_by!(
-  email: 'user-with-retro@example.com',
-  name: 'Alda Retros',
-  auth_token: 'secret-test-user-token-ef87c521b971'
+    email: 'user-with-retro@example.com',
+    name: 'Alda Retros',
+    auth_token: 'secret-test-user-token-ef87c521b971'
+)
+
+spartacus = User.find_or_create_by!(
+    email: 'user-spartacus-carloman@example.com',
+    name: 'Spartacus Carloman',
+    auth_token: 'secret-test-user-token-ef87c521b972'
 )
 
 Retro.find_or_create_by!(
   name: "Alda's personal retro",
   user: alda
+)
+
+
+Retro.find_or_create_by!(
+    name: "Spartacus undesired personal retro",
+    user: spartacus
 )

--- a/e2e/spec/alex_journey_spec.rb
+++ b/e2e/spec/alex_journey_spec.rb
@@ -33,7 +33,7 @@ require 'spec_helper'
 describe 'Alex', type: :feature, js: true do
   describe 'on the users page' do
     context 'when a user has retros' do
-      specify 'can delete that user' do
+      specify 'can not delete that user' do
         visit_active_admin_page
 
         fill_in 'admin_user_email', with: 'admin@example.com'
@@ -64,6 +64,56 @@ describe 'Alex', type: :feature, js: true do
 
         expect(page).to_not have_content 'Rey Troless'
       end
+    end
+  end
+  describe 'on the retros page' do
+    fspecify 'can change the owner to another user' do
+      visit_active_admin_page
+
+      fill_in 'admin_user_email', with: 'admin@example.com'
+      fill_in 'admin_user_password', with: 'secret'
+      click_on 'Login'
+
+      click_on 'Retros'
+      fill_in 'q_name', with: 'Spartacus'
+      click_on 'Filter'
+
+      click_on 'Edit'
+
+      expect(page).to have_content 'Owner Email'
+      expect(find_field('retro_owner_email').value).to eq 'user-spartacus-carloman@example.com'
+
+      fill_in 'retro_owner_email', with: 'user-with-retro@example.com'
+
+      click_on 'Update Retro'
+
+      first(:link, 'Retros').click
+      fill_in 'q_name', with: 'Spartacus'
+      click_on 'Filter'
+
+      click_on 'Edit'
+
+      expect(find_field('retro_owner_email').value).to eq 'user-with-retro@example.com'
+    end
+
+    specify 'the new owner email does not match any user' do
+      visit_active_admin_page
+
+      fill_in 'admin_user_email', with: 'admin@example.com'
+      fill_in 'admin_user_password', with: 'secret'
+      click_on 'Login'
+
+      click_on 'Retros'
+      fill_in 'q_name', with: 'Spartacus'
+      click_on 'Filter'
+
+      click_on 'Edit'
+
+      fill_in 'retro_owner_email', with: 'wrong@example.com'
+
+      click_on 'Update Retro'
+
+      expect(page).to have_content 'Could not change owners. User not found by email.'
     end
   end
 end


### PR DESCRIPTION
This PR adds the ability to change the retro owner using the owner email address from the admin panel.

On the edit retro page there's a new field 'Owner Email', if the email does not belongs to any of the users it will provide an error message stating that. 

This finishes #4.

----

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the API unit tests using `bundle exec rake` from the `/api` submodule.

* [x] I have run all the WEB unit tests using `gulp spec-app` from the `/web` submodule.

* [x] I have run all the acceptance tests using `gulp local-acceptance` from the `/web` submodule.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added
