### PR TITLE
App Name in PWS Deployment Manifest

### DIFF
--- a/deployment/pws/deploy.sh
+++ b/deployment/pws/deploy.sh
@@ -3,7 +3,7 @@
 set -e
 
 cf push -f deployment/pws/config/manifest-api.yml -p api
-cf run-task api-app-name 'ADMIN_EMAIL=email@example.com ADMIN_PASSWORD=password rake admin:create_user'
+cf run-task {{api-app-name}} 'ADMIN_EMAIL=email@example.com ADMIN_PASSWORD=password rake admin:create_user'
 
 pushd web
   NODE_ENV=production gulp assets


### PR DESCRIPTION
The API App Name wasn't cited as a variable to change prior to deployment, which resulted in the following error:
`App api-app-name not found`

Thanks for contributing to postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the API unit tests using `bundle exec rake` from the `/api` submodule.

* [x] I have run all the WEB unit tests using `gulp spec-app` from the `/web` submodule.

* [x] I have run all the acceptance tests using `gulp local-acceptance` from the `/web` submodule.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added
