### PR TITLE
Add mixpanel in as optional analytics

### DIFF
--- a/web/app/components/application.js
+++ b/web/app/components/application.js
@@ -39,6 +39,7 @@ const {useRouter} = require('./use_router');
 const Router = require('./router');
 const Header = require('./header');
 const Logger = require('../../helpers/logger');
+
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import injectTapEventPlugin from 'react-tap-event-plugin';
@@ -60,6 +61,7 @@ class Application extends React.Component {
   componentDidMount() {
     injectTapEventPlugin();
     Logger.info('Application started');
+    window.Mixpanel = require('mixpanel-browser');
   }
 
   render() {

--- a/web/app/dispatchers/main_dispatcher.js
+++ b/web/app/dispatchers/main_dispatcher.js
@@ -108,6 +108,7 @@ const MainDispatcher = {
         this.$store.refine('retro', 'highlighted_item_id').set(null);
         this.$store.refine('retro', 'items', data.item, 'done').set(true);
         this.dispatch({type: 'checkAllRetroItemsDone'});
+
         this.dispatch({
             type: 'completedRetroItemAnalytics',
             data: {retroId: data.retroId, category: data.item.category}
@@ -284,7 +285,7 @@ const MainDispatcher = {
         this.$store.refine('featureFlags').merge({
             newTerms: data.new_terms,
             oldTerms: data.old_terms,
-              archiveEmails: data.archive_emails
+            archiveEmails: data.archive_emails
         });
     },
     setCountryCode({data}) {

--- a/web/helpers/analytics.js
+++ b/web/helpers/analytics.js
@@ -28,17 +28,23 @@
  *
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+const POSTFACTO_TEAM_ANALYTICS_TOKEN = "d4de349453cc697734eced9ebedcdb22";
 
 class Analytics {
+  static initialized = false;
 
   static track(event, options) {
-    options = options || {};
-    if (typeof analytics !== 'undefined') {
+    if (global.Retro.config.enable_analytics) {
+      if (!Analytics.initialized) {
+        window.Mixpanel.init(POSTFACTO_TEAM_ANALYTICS_TOKEN);
+        Analytics.initialized = true;
+      }
+
+      options = options || {};
       options.timestamp = (new Date()).toJSON();
-      analytics.track(event, options);
+      window.Mixpanel.track(event, options);
     }
   }
-
 }
 
 module.exports = Analytics;

--- a/web/npm-shrinkwrap.json
+++ b/web/npm-shrinkwrap.json
@@ -2,6 +2,7 @@
   "name": "react-starter",
   "version": "0.0.1",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@types/react": {
       "version": "https://registry.npmjs.org/@types/react/-/react-0.14.55.tgz",
@@ -15,7 +16,11 @@
     },
     "accepts": {
       "version": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo="
+      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+      "requires": {
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+        "negotiator": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+      }
     },
     "acorn": {
       "version": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
@@ -25,7 +30,10 @@
     "acorn-jsx": {
       "version": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
+      }
     },
     "actioncable": {
       "version": "https://registry.npmjs.org/actioncable/-/actioncable-5.0.1.tgz",
@@ -34,7 +42,11 @@
     "ajv": {
       "version": "https://registry.npmjs.org/ajv/-/ajv-4.10.3.tgz",
       "integrity": "sha1-Pk/qlnWxV954iLgN0O1zW4PyjhE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+      }
     },
     "ajv-keywords": {
       "version": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.0.tgz",
@@ -44,7 +56,12 @@
     "align-text": {
       "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+        "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+      }
     },
     "alphanum-sort": {
       "version": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
@@ -83,7 +100,11 @@
     "anymatch": {
       "version": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
       "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
+      }
     },
     "aproba": {
       "version": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
@@ -94,6 +115,16 @@
       "version": "https://registry.npmjs.org/archiver/-/archiver-1.0.0.tgz",
       "integrity": "sha1-3h1hCC6Ud1W1mbs7wnEwpMhZ/IM=",
       "dev": true,
+      "requires": {
+        "archiver-utils": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+        "buffer-crc32": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+        "tar-stream": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
+        "zip-stream": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.1.0.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -103,7 +134,16 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     },
@@ -111,6 +151,14 @@
       "version": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
       "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
       "dev": true,
+      "requires": {
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "lazystream": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -125,7 +173,16 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     },
@@ -137,17 +194,27 @@
     "are-we-there-yet": {
       "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
       "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delegates": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+      }
     },
     "argparse": {
       "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+      }
     },
     "arr-diff": {
       "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+      }
     },
     "arr-flatten": {
       "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
@@ -176,7 +243,11 @@
     "array-index": {
       "version": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
       "integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
+      }
     },
     "array-map": {
       "version": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
@@ -191,7 +262,10 @@
     "array-union": {
       "version": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
+      }
     },
     "array-uniq": {
       "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
@@ -220,7 +294,10 @@
     "assert": {
       "version": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+      }
     },
     "assert-plus": {
       "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
@@ -255,7 +332,15 @@
     "autoprefixer": {
       "version": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.6.1.tgz",
       "integrity": "sha1-EaQHertLMTJT7C9uGtuRrYQlNRk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-1.5.1.tgz",
+        "caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000604.tgz",
+        "normalize-range": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+        "num2fraction": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "autosize": {
       "version": "https://registry.npmjs.org/autosize/-/autosize-3.0.20.tgz",
@@ -280,6 +365,11 @@
       "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.20.0.tgz",
       "integrity": "sha1-uWj4OQkPmovG1Bk4+5bLhPc4eyY=",
       "dev": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
+      },
       "dependencies": {
         "esutils": {
           "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -291,32 +381,85 @@
     "babel-core": {
       "version": "https://registry.npmjs.org/babel-core/-/babel-core-6.21.0.tgz",
       "integrity": "sha1-dVJUgMIcgD+CbvOGfSLBnwgKNyQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.20.0.tgz",
+        "babel-generator": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.21.0.tgz",
+        "babel-helpers": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
+        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
+        "babel-register": "https://registry.npmjs.org/babel-register/-/babel-register-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz",
+        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
+        "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+        "private": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
+        "slash": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      }
     },
     "babel-eslint": {
       "version": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz",
       "integrity": "sha1-UpNBn+NnLWZZjTJ9qWlFZ7pqXy8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz",
+        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
+        "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+        "lodash.pickby": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz"
+      }
     },
     "babel-generator": {
       "version": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.21.0.tgz",
       "integrity": "sha1-YF8SacSJocdd7sp+oW1D1GVshJQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz",
+        "detect-indent": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+        "jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      }
     },
     "babel-helper-bindify-decorators": {
       "version": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.18.0.tgz",
       "integrity": "sha1-/ADFc2dqbnAv/6AAGVgIkuyHgKU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.18.0.tgz",
       "integrity": "sha1-iugUmJ96U2ghUuNAGgT6vQuzM6Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-assignable-expression": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-helper-builder-react-jsx": {
       "version": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.21.1.tgz",
       "integrity": "sha1-xKJCCGVb6dwczPFNNm2hdvIGReQ=",
       "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz",
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      },
       "dependencies": {
         "esutils": {
           "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -328,77 +471,155 @@
     "babel-helper-call-delegate": {
       "version": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.18.0.tgz",
       "integrity": "sha1-BbFKr6QwiEsDQJfvKenwZ+pBM70=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-helper-define-map": {
       "version": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz",
       "integrity": "sha1-jWyF3H+7TBm+PeQEdNGOl8NnbsI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      }
     },
     "babel-helper-explode-assignable-expression": {
       "version": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.18.0.tgz",
       "integrity": "sha1-FLjowtA61zXUsg8YQLJM0fZSOf4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-helper-explode-class": {
       "version": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.18.0.tgz",
       "integrity": "sha1-xE929PojucXWB8usXUEV56dvYss=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-bindify-decorators": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-helper-function-name": {
       "version": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
       "integrity": "sha1-aOxxrrofPiiypvBzAZC3VKm/MOY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-helper-get-function-arity": {
       "version": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
       "integrity": "sha1-pbGWlf0/nN/DKDmLR9r81wlPnyQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-helper-hoist-variables": {
       "version": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.18.0.tgz",
       "integrity": "sha1-qDW1q4tG1t6bq++uTZjqQehmuCo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-helper-optimise-call-expression": {
       "version": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.18.0.tgz",
       "integrity": "sha1-kmHQKZ7hpPCKbdKLe3x3c0j9jw8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-helper-regex": {
       "version": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.18.0.tgz",
       "integrity": "sha1-rg6/133obLLxryWOLMILX+iT7MY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      }
     },
     "babel-helper-remap-async-to-generator": {
       "version": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.20.3.tgz",
       "integrity": "sha1-ndOzlvE+Ne9j5TgJhQCtwkxjxOc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-helper-replace-supers": {
       "version": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.18.0.tgz",
       "integrity": "sha1-KOxph3vkFE29ZPTMOjN+ifKakk4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-optimise-call-expression": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.18.0.tgz",
+        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-helpers": {
       "version": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
       "integrity": "sha1-EJXsENmSeUYFU+Z+s+7plz04Z+M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
+      }
     },
     "babel-loader": {
       "version": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.2.10.tgz",
       "integrity": "sha1-re/CskIyDNXRXmWzHOoOixsC1LA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-cache-dir": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+      }
     },
     "babel-messages": {
       "version": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
       "integrity": "sha1-v1BHNsqWfm1l7wrbWipflHyODrk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-check-es2015-constants": {
       "version": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
       "integrity": "sha1-2/Akwy7Te/2o3uHnbaAjhqjSb+c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-syntax-async-functions": {
       "version": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
@@ -473,265 +694,551 @@
     "babel-plugin-transform-async-generator-functions": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.17.0.tgz",
       "integrity": "sha1-0LWisvCUDyskX6IKAFGe17xsrlQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.20.3.tgz",
+        "babel-plugin-syntax-async-generators": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz",
       "integrity": "sha1-Gew2yxSGtZ+fRorfpCzhOQjKKZk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.20.3.tgz",
+        "babel-plugin-syntax-async-functions": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-class-constructor-call": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.18.0.tgz",
       "integrity": "sha1-gIVeOKGrR7jGxkf46hvNLADKOq4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-class-constructor-call": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
+      }
     },
     "babel-plugin-transform-class-properties": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.19.0.tgz",
       "integrity": "sha1-EnSzSauq3INRZOIAT0okRKJ4jV8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
+        "babel-plugin-syntax-class-properties": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
+      }
     },
     "babel-plugin-transform-decorators": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.13.0.tgz",
       "integrity": "sha1-gtZcFHCug+LRPuvssKHCR21i2p0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-define-map": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz",
+        "babel-helper-explode-class": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.18.0.tgz",
+        "babel-plugin-syntax-decorators": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-plugin-transform-do-expressions": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.8.0.tgz",
       "integrity": "sha1-/aaSrzOYNcwlW7dUTvuPfBMGwnM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-do-expressions": "https://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
       "integrity": "sha1-W2Ovwxgb3JqMTUgbWk8/fX/vPZ0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
       "integrity": "sha1-7ZXWKcS1pxriloK5mPcNmDPrNm0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.21.0.tgz",
       "integrity": "sha1-6EBof5IucPssQrsTUBg4wXShFe0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      }
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.18.0.tgz",
       "integrity": "sha1-/+ehcyG/g+SU3NoK4/xy30j/0dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-define-map": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz",
+        "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
+        "babel-helper-optimise-call-expression": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.18.0.tgz",
+        "babel-helper-replace-supers": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.18.0.tgz",
+        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
       "integrity": "sha1-9RAQ/WGzvXtrYKX9/TB7t6UnmHA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-define-map": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.19.0.tgz",
       "integrity": "sha1-/x2RHEs/TKtiG9ZnAqhprNGQBTM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
       "integrity": "sha1-/Y9/cXH8EIzBxwwxZLnxWoHCX30=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.18.0.tgz",
       "integrity": "sha1-TFF1BNtkv4z8EZprjxdyEfICinA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
       "integrity": "sha1-jBNbF9vQZOW7pW7FEbqu4vyoJxk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
       "integrity": "sha1-UKouXHlY/CqyXXTsEX4MyY8EZGg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.18.0.tgz",
       "integrity": "sha1-SaBUy7divfmuLYqAcHbPreYUHkA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.18.0.tgz",
       "integrity": "sha1-wVrluxGzKgq9zJilg3uqTujWe8w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-strict-mode": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.19.0.tgz",
       "integrity": "sha1-UEOBNuunRSfvoApbD++vHcQHHaY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.18.0.tgz",
       "integrity": "sha1-IzUXcOzlwfjoPtZ8sdeZKIRJHlA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
       "integrity": "sha1-G4WHQKWkQAiHwj3P9vTVbupKJMU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-replace-supers": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.21.0.tgz",
       "integrity": "sha1-RqZV5oZO+YQJFEjN8CTYe2Cyp9g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-call-delegate": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.18.0.tgz",
+        "babel-helper-get-function-arity": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.18.0.tgz",
       "integrity": "sha1-4u3jt99Hv5gBUZJlNNHdDL6lj0M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
       "integrity": "sha1-Ahf3N+O4IfpaZp8YfG7VkgXwXpw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
       "integrity": "sha1-5z0wCkQKNdXGT1wqNE3CNuPfR74=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
       "integrity": "sha1-huuHbQosY12k7ASLT33p38iX5ms=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.18.0.tgz",
       "integrity": "sha1-CxTEhinJD/R6BlAHf2qmmb7jV5g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
       "integrity": "sha1-YpjOq6rYjVCj9POS2N6ZcmD27yw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "regexpu-core": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz"
+      }
     },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.8.0.tgz",
       "integrity": "sha1-2yV0LpM56t5nbKms7Eb5VVmaaKQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.18.0.tgz",
+        "babel-plugin-syntax-exponentiation-operator": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-export-extensions": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.8.0.tgz",
       "integrity": "sha1-+oD/ZVtjZUlDG/049rgXvYLkf1s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-export-extensions": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-flow-strip-types": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.21.0.tgz",
       "integrity": "sha1-Luo/i1uyNDObRyg/6sFVz7I3uUg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-flow": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-function-bind": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.8.0.tgz",
       "integrity": "sha1-5/M0zmn1DSj+hQqCLqqrn6T02CE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-function-bind": "https://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-object-assign": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.8.0.tgz",
       "integrity": "sha1-duF/LcDzbxT1SLmv16rvWNKeu3U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-object-rest-spread": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.20.2.tgz",
       "integrity": "sha1-6BbFW7p3sUwWNl2H4q5IyP0Y/C4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-react-display-name": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.8.0.tgz",
       "integrity": "sha1-96CEl3OD1yi9vcKDW7oBWVd/Zg4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-react-jsx": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.8.0.tgz",
       "integrity": "sha1-lHWZQvcK8YxhcYmqfzWT8WRKcas=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-react-jsx": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.21.1.tgz",
+        "babel-plugin-syntax-jsx": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-react-jsx-self": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.11.0.tgz",
       "integrity": "sha1-YFyUUMFCn5epMPfh3+Pw2dDb0PQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-jsx": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-react-jsx-source": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.9.0.tgz",
       "integrity": "sha1-r2hKBcIGeobglX1PNDKVzPXczwA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-jsx": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      }
     },
     "babel-plugin-transform-regenerator": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.21.0.tgz",
       "integrity": "sha1-ddDH5/hPN5NY9QhFHGiixfpalwM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.8.tgz"
+      }
     },
     "babel-plugin-transform-strict-mode": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.18.0.tgz",
       "integrity": "sha1-33zymR/gRvRBY9zRENXKQ7xlK50=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      }
     },
     "babel-polyfill": {
       "version": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.20.0.tgz",
-      "integrity": "sha1-3ko3EAYTniCZCqwL42fTmDMSBOc="
+      "integrity": "sha1-3ko3EAYTniCZCqwL42fTmDMSBOc=",
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+        "regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz"
+      }
     },
     "babel-preset-es2015": {
       "version": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.18.0.tgz",
       "integrity": "sha1-uMcN+E7JSMQ9zyv3cOmI632ogxI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
+        "babel-plugin-transform-es2015-arrow-functions": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
+        "babel-plugin-transform-es2015-block-scoped-functions": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
+        "babel-plugin-transform-es2015-block-scoping": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.21.0.tgz",
+        "babel-plugin-transform-es2015-classes": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.18.0.tgz",
+        "babel-plugin-transform-es2015-computed-properties": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
+        "babel-plugin-transform-es2015-destructuring": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.19.0.tgz",
+        "babel-plugin-transform-es2015-duplicate-keys": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
+        "babel-plugin-transform-es2015-for-of": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.18.0.tgz",
+        "babel-plugin-transform-es2015-function-name": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
+        "babel-plugin-transform-es2015-literals": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
+        "babel-plugin-transform-es2015-modules-amd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.18.0.tgz",
+        "babel-plugin-transform-es2015-modules-commonjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.18.0.tgz",
+        "babel-plugin-transform-es2015-modules-systemjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.19.0.tgz",
+        "babel-plugin-transform-es2015-modules-umd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.18.0.tgz",
+        "babel-plugin-transform-es2015-object-super": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
+        "babel-plugin-transform-es2015-parameters": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.21.0.tgz",
+        "babel-plugin-transform-es2015-shorthand-properties": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.18.0.tgz",
+        "babel-plugin-transform-es2015-spread": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
+        "babel-plugin-transform-es2015-sticky-regex": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
+        "babel-plugin-transform-es2015-template-literals": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
+        "babel-plugin-transform-es2015-typeof-symbol": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.18.0.tgz",
+        "babel-plugin-transform-es2015-unicode-regex": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
+        "babel-plugin-transform-regenerator": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.21.0.tgz"
+      }
     },
     "babel-preset-es2015-loose": {
       "version": "https://registry.npmjs.org/babel-preset-es2015-loose/-/babel-preset-es2015-loose-7.0.0.tgz",
       "integrity": "sha1-/YDIXTsgy/MJvQzjCjY4DFeEvwY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "modify-babel-preset": "https://registry.npmjs.org/modify-babel-preset/-/modify-babel-preset-1.2.0.tgz"
+      }
     },
     "babel-preset-react": {
       "version": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.16.0.tgz",
       "integrity": "sha1-qhF9YN4JKGB+NDxIKJBuRmGCQxY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-flow": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+        "babel-plugin-syntax-jsx": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+        "babel-plugin-transform-flow-strip-types": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.21.0.tgz",
+        "babel-plugin-transform-react-display-name": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.8.0.tgz",
+        "babel-plugin-transform-react-jsx": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.8.0.tgz",
+        "babel-plugin-transform-react-jsx-self": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.11.0.tgz",
+        "babel-plugin-transform-react-jsx-source": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.9.0.tgz"
+      }
     },
     "babel-preset-stage-0": {
       "version": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.16.0.tgz",
       "integrity": "sha1-9aJjxCBTL9V0kfGnMVswNuQo+CM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-do-expressions": "https://registry.npmjs.org/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.8.0.tgz",
+        "babel-plugin-transform-function-bind": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.8.0.tgz",
+        "babel-preset-stage-1": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.16.0.tgz"
+      }
     },
     "babel-preset-stage-1": {
       "version": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.16.0.tgz",
       "integrity": "sha1-nTH7va57F8VJ/TrJPjz2kCaV5Hk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-class-constructor-call": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.18.0.tgz",
+        "babel-plugin-transform-export-extensions": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.8.0.tgz",
+        "babel-preset-stage-2": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.18.0.tgz"
+      }
     },
     "babel-preset-stage-2": {
       "version": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.18.0.tgz",
       "integrity": "sha1-nre/mo6RxoJg1bp1AEk8qq2ktbU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-dynamic-import": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+        "babel-plugin-transform-class-properties": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.19.0.tgz",
+        "babel-plugin-transform-decorators": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.13.0.tgz",
+        "babel-preset-stage-3": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.17.0.tgz"
+      }
     },
     "babel-preset-stage-3": {
       "version": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.17.0.tgz",
       "integrity": "sha1-tmOORttukeP4iQE9jOFDkXxoXjk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-trailing-function-commas": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.20.0.tgz",
+        "babel-plugin-transform-async-generator-functions": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.17.0.tgz",
+        "babel-plugin-transform-async-to-generator": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz",
+        "babel-plugin-transform-exponentiation-operator": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.8.0.tgz",
+        "babel-plugin-transform-object-rest-spread": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.20.2.tgz"
+      }
     },
     "babel-register": {
       "version": "https://registry.npmjs.org/babel-register/-/babel-register-6.18.0.tgz",
       "integrity": "sha1-iS4uA4ZQeN2QrSxxURHsREmzKmg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-6.21.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+        "home-or-tmp": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "source-map-support": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.8.tgz"
+      }
     },
     "babel-runtime": {
       "version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
-      "integrity": "sha1-hzAL3PTNdw8JvwBIxkIE4XgG0W8="
+      "integrity": "sha1-hzAL3PTNdw8JvwBIxkIE4XgG0W8=",
+      "requires": {
+        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+        "regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz"
+      }
     },
     "babel-template": {
       "version": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
       "integrity": "sha1-4UndGp8Do1+BfdvE0EgZiOfryMo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz",
+        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      }
     },
     "babel-traverse": {
       "version": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz",
       "integrity": "sha1-acY2WATxpPaesSE/hbAKgYuMIa0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.20.0.tgz",
+        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz",
+        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "globals": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
+        "invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      }
     },
     "babel-types": {
       "version": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz",
       "integrity": "sha1-MUuSFoiR7204Brf3qRf9+HwRpLI=",
       "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "to-fast-properties": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
+      },
       "dependencies": {
         "esutils": {
           "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -779,7 +1286,10 @@
       "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
       "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+      }
     },
     "beeper": {
       "version": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
@@ -800,18 +1310,30 @@
       "version": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
       "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
       "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+      },
       "dependencies": {
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
         }
       }
     },
     "block-stream": {
       "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
     },
     "bluebird": {
       "version": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
@@ -822,6 +1344,18 @@
       "version": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
       "integrity": "sha1-wIzzMMM1jhUQFqBXRvE/ApyX+pc=",
       "dev": true,
+      "requires": {
+        "bytes": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
+        "content-type": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "depd": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
+        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
+        "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+        "raw-body": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+        "type-is": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz"
+      },
       "dependencies": {
         "depd": {
           "version": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
@@ -831,7 +1365,11 @@
         "http-errors": {
           "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
           "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+          }
         },
         "iconv-lite": {
           "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
@@ -848,7 +1386,10 @@
     "boom": {
       "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+      }
     },
     "bowser": {
       "version": "https://registry.npmjs.org/bowser/-/bowser-1.6.0.tgz",
@@ -858,32 +1399,55 @@
     "brace-expansion": {
       "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
       "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+      }
     },
     "braces": {
       "version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "expand-range": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+        "preserve": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+        "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+      }
     },
     "browserify-aes": {
       "version": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz",
       "integrity": "sha1-BnFJtmjfMcS1hTPgLQHoBthgjiw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
     },
     "browserify-zlib": {
       "version": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pako": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
+      }
     },
     "browserslist": {
       "version": "https://registry.npmjs.org/browserslist/-/browserslist-1.5.1.tgz",
       "integrity": "sha1-Z8PyoaatF0zQHSXSNi5uYIOyaYY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000604.tgz"
+      }
     },
     "buffer": {
       "version": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
+      "requires": {
+        "base64-js": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+        "ieee754": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -906,6 +1470,9 @@
       "version": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.1.tgz",
       "integrity": "sha1-AWE3MGCsWYjv+ZBYcxEU9uGV1R4=",
       "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -915,7 +1482,16 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     },
@@ -937,7 +1513,10 @@
     "caller-path": {
       "version": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsites": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
+      }
     },
     "callsites": {
       "version": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
@@ -952,7 +1531,11 @@
     "camelcase-keys": {
       "version": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+        "map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+      }
     },
     "can-use-dom": {
       "version": "https://registry.npmjs.org/can-use-dom/-/can-use-dom-0.1.0.tgz",
@@ -972,17 +1555,32 @@
     "cbify": {
       "version": "https://registry.npmjs.org/cbify/-/cbify-1.0.0.tgz",
       "integrity": "sha1-GnrUBEsvkjF+ehut2jpydgeDXYQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fn-args": "https://registry.npmjs.org/fn-args/-/fn-args-1.0.0.tgz",
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+      }
     },
     "center-align": {
       "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+      }
     },
     "chalk": {
       "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+        "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+      }
     },
     "change-emitter": {
       "version": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.2.tgz",
@@ -992,7 +1590,18 @@
     "chokidar": {
       "version": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
       "integrity": "sha1-L0RHq16W5Q+z14n9kNTHLg5McMI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "anymatch": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+        "async-each": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+        "fsevents": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.17.tgz",
+        "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "is-binary-path": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+        "readdirp": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz"
+      }
     },
     "circular-json": {
       "version": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
@@ -1002,7 +1611,10 @@
     "clap": {
       "version": "https://registry.npmjs.org/clap/-/clap-1.1.2.tgz",
       "integrity": "sha1-MWVFvyIikiWizsqmgkzS9WqXCe0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+      }
     },
     "classnames": {
       "version": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
@@ -1012,7 +1624,10 @@
     "cli-cursor": {
       "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "restore-cursor": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
+      }
     },
     "cli-width": {
       "version": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
@@ -1022,7 +1637,12 @@
     "cliui": {
       "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+        "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+      }
     },
     "clone": {
       "version": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
@@ -1042,7 +1662,10 @@
     "coa": {
       "version": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
       "integrity": "sha1-f5WTRs/IcZ4/cjPNaFKFSnxn2KM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "q": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+      }
     },
     "code-point-at": {
       "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -1052,12 +1675,20 @@
     "color": {
       "version": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+        "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.8.2.tgz",
+        "color-string": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz"
+      }
     },
     "color-convert": {
       "version": "https://registry.npmjs.org/color-convert/-/color-convert-1.8.2.tgz",
       "integrity": "sha1-voaBhNfIYxdm1U5weOJnLXx+Mzk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color-name": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
+      }
     },
     "color-name": {
       "version": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
@@ -1067,12 +1698,20 @@
     "color-string": {
       "version": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color-name": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
+      }
     },
     "colormin": {
       "version": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+        "css-color-names": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
+      }
     },
     "colors": {
       "version": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
@@ -1082,12 +1721,18 @@
     "combined-stream": {
       "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+      }
     },
     "commander": {
       "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+      }
     },
     "commondir": {
       "version": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1098,6 +1743,12 @@
       "version": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.1.0.tgz",
       "integrity": "sha1-n0RguxKIVkx0c5FuApiqPDINyts=",
       "dev": true,
+      "requires": {
+        "buffer-crc32": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+        "crc32-stream": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-1.0.0.tgz",
+        "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -1107,24 +1758,48 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     },
     "compressible": {
       "version": "https://registry.npmjs.org/compressible/-/compressible-2.0.9.tgz",
       "integrity": "sha1-baq04rWZwncN2eIeeokbHFp1VCU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
+      }
     },
     "compression": {
       "version": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz",
       "integrity": "sha1-sDuNhub4rSloPLqN+R3cb/x3s5U=",
       "dev": true,
+      "requires": {
+        "accepts": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
+        "bytes": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
+        "compressible": "https://registry.npmjs.org/compressible/-/compressible-2.0.9.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "on-headers": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+        "vary": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
+      },
       "dependencies": {
         "accepts": {
           "version": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
           "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+            "negotiator": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+          }
         },
         "negotiator": {
           "version": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
@@ -1147,6 +1822,11 @@
       "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
       "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
       "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+        "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -1156,7 +1836,15 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     },
@@ -1164,6 +1852,39 @@
       "version": "https://registry.npmjs.org/connect/-/connect-2.30.2.tgz",
       "integrity": "sha1-jam8vooFTT0xjXTf7JA7XDmhtgk=",
       "dev": true,
+      "requires": {
+        "basic-auth-connect": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
+        "body-parser": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
+        "bytes": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
+        "compression": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz",
+        "connect-timeout": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz",
+        "content-type": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+        "cookie": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
+        "cookie-parser": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
+        "cookie-signature": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+        "csurf": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "depd": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
+        "errorhandler": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.3.tgz",
+        "express-session": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz",
+        "finalhandler": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
+        "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+        "method-override": "https://registry.npmjs.org/method-override/-/method-override-2.3.7.tgz",
+        "morgan": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
+        "multiparty": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
+        "on-headers": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+        "pause": "https://registry.npmjs.org/pause/-/pause-0.1.0.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+        "response-time": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
+        "serve-favicon": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.2.tgz",
+        "serve-index": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz",
+        "serve-static": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
+        "type-is": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
+        "utils-merge": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+        "vhost": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz"
+      },
       "dependencies": {
         "cookie": {
           "version": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
@@ -1183,12 +1904,22 @@
         "finalhandler": {
           "version": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
           "integrity": "sha1-llpS2ejQXSuFdUhUH7ibU6JJfZs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+            "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz",
+            "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "unpipe": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+          }
         },
         "http-errors": {
           "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
           "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+          }
         },
         "qs": {
           "version": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
@@ -1204,6 +1935,20 @@
           "version": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
           "integrity": "sha1-dl52B8gFVFK7pvCwUllTUJhgNt4=",
           "dev": true,
+          "requires": {
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+            "depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+            "destroy": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+            "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "etag": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+            "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+            "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+            "mime": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+            "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
+            "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+          },
           "dependencies": {
             "depd": {
               "version": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
@@ -1226,6 +1971,11 @@
           "version": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
           "integrity": "sha1-zlpuzTEB/tXsCYJ9rCKpwpv7BTU=",
           "dev": true,
+          "requires": {
+            "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+            "send": "https://registry.npmjs.org/send/-/send-0.13.2.tgz"
+          },
           "dependencies": {
             "escape-html": {
               "version": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1245,18 +1995,31 @@
       "version": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz",
       "integrity": "sha1-3ppexh4zoStu2qt7XwYumMWZuI4=",
       "dev": true,
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+        "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+        "on-headers": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
+      },
       "dependencies": {
         "http-errors": {
           "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
           "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+          }
         }
       }
     },
     "console-browserify": {
       "version": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "date-now": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+      }
     },
     "console-control-strings": {
       "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -1289,6 +2052,10 @@
       "version": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
       "integrity": "sha1-nXVVcPtdF4kHcSJ6AjFNm+fPg1Y=",
       "dev": true,
+      "requires": {
+        "cookie": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
+        "cookie-signature": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+      },
       "dependencies": {
         "cookie": {
           "version": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
@@ -1313,7 +2080,10 @@
     "cors": {
       "version": "https://registry.npmjs.org/cors/-/cors-2.8.1.tgz",
       "integrity": "sha1-YYGqVqu0WiglvjMEcDdHrk6dI4M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "vary": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
+      }
     },
     "crc": {
       "version": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz",
@@ -1324,6 +2094,10 @@
       "version": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-1.0.0.tgz",
       "integrity": "sha1-6hVeXh1zjtN3hDj/6S/+KhQa6z8=",
       "dev": true,
+      "requires": {
+        "buffer-crc32": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -1333,7 +2107,16 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     },
@@ -1341,18 +2124,29 @@
       "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
       "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
       "dev": true,
+      "requires": {
+        "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.2.12.tgz"
+      },
       "dependencies": {
         "lru-cache": {
           "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
           "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
+          }
         }
       }
     },
     "cryptiles": {
       "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+      }
     },
     "crypto": {
       "version": "https://registry.npmjs.org/crypto/-/crypto-0.0.3.tgz",
@@ -1362,22 +2156,43 @@
     "crypto-browserify": {
       "version": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz",
       "integrity": "sha1-ufx1u0oO1h3PHNXa6W6zDJw+UGw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserify-aes": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz",
+        "pbkdf2-compat": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
+        "ripemd160": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
+        "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+      }
     },
     "csrf": {
       "version": "https://registry.npmjs.org/csrf/-/csrf-3.0.4.tgz",
       "integrity": "sha1-ugFCPltb6ntlXjiwvdEyOVTL2qU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "base64-url": "https://registry.npmjs.org/base64-url/-/base64-url-1.3.3.tgz",
+        "rndm": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+        "tsscmp": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz",
+        "uid-safe": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.3.tgz"
+      }
     },
     "css": {
       "version": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
       "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
       "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+        "source-map-resolve": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+        "urix": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
+      },
       "dependencies": {
         "source-map": {
           "version": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+          }
         }
       }
     },
@@ -1390,23 +2205,46 @@
       "version": "https://registry.npmjs.org/css-loader/-/css-loader-0.23.1.tgz",
       "integrity": "sha1-n6I/K1wJZSNZEK1ezvO4o2OQ/lA=",
       "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.5.4.tgz",
+        "cssnano": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
+        "lodash.camelcase": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "postcss-modules-extract-imports": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.0.1.tgz",
+        "postcss-modules-local-by-default": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.1.1.tgz",
+        "postcss-modules-scope": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.0.2.tgz",
+        "postcss-modules-values": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.2.2.tgz",
+        "source-list-map": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.7.tgz"
+      },
       "dependencies": {
         "lodash.camelcase": {
           "version": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
           "integrity": "sha1-kyyLh/ikN3iXxnGXUzKC+Xrqwpg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._createcompounder": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz"
+          }
         }
       }
     },
     "css-parse": {
       "version": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz",
       "integrity": "sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "css": "https://registry.npmjs.org/css/-/css-2.2.1.tgz"
+      }
     },
     "css-selector-tokenizer": {
       "version": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.5.4.tgz",
       "integrity": "sha1-E5uv00o1/QwUKEhwSeBpnm9qLCE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cssesc": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+        "fastparse": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
+      }
     },
     "css-value": {
       "version": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
@@ -1421,17 +2259,61 @@
     "cssnano": {
       "version": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "autoprefixer": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.6.1.tgz",
+        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+        "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "postcss-calc": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+        "postcss-colormin": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.1.tgz",
+        "postcss-convert-values": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.0.tgz",
+        "postcss-discard-comments": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+        "postcss-discard-duplicates": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.2.tgz",
+        "postcss-discard-empty": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+        "postcss-discard-overridden": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+        "postcss-discard-unused": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+        "postcss-filter-plugins": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+        "postcss-merge-idents": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+        "postcss-merge-longhand": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz",
+        "postcss-merge-rules": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.11.tgz",
+        "postcss-minify-font-values": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+        "postcss-minify-gradients": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+        "postcss-minify-params": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+        "postcss-minify-selectors": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+        "postcss-normalize-charset": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+        "postcss-normalize-url": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+        "postcss-ordered-values": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.2.tgz",
+        "postcss-reduce-idents": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+        "postcss-reduce-initial": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+        "postcss-reduce-transforms": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+        "postcss-svgo": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+        "postcss-unique-selectors": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+        "postcss-zindex": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz"
+      }
     },
     "csso": {
       "version": "https://registry.npmjs.org/csso/-/csso-2.2.1.tgz",
       "integrity": "sha1-Ufu1NH5Q6B5u1RZopISQrm/ir+I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clap": "https://registry.npmjs.org/clap/-/clap-1.1.2.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      }
     },
     "csurf": {
       "version": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz",
       "integrity": "sha1-I/KhO/HY/OHQyZZYg5RELLqGpWo=",
       "dev": true,
+      "requires": {
+        "cookie": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
+        "cookie-signature": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+        "csrf": "https://registry.npmjs.org/csrf/-/csrf-3.0.4.tgz",
+        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
+      },
       "dependencies": {
         "cookie": {
           "version": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
@@ -1441,7 +2323,11 @@
         "http-errors": {
           "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
           "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+          }
         }
       }
     },
@@ -1453,17 +2339,26 @@
     "currently-unhandled": {
       "version": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-find-index": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
+      }
     },
     "d": {
       "version": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
       "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
+      }
     },
     "dashdash": {
       "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "requires": {
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -1484,12 +2379,20 @@
     },
     "debug": {
       "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo="
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "requires": {
+        "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+      }
     },
     "debug-fabulous": {
       "version": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
       "integrity": "sha1-+gccXYdIRoVCSAdCHKSxawsaB2M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "lazy-debug-legacy": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+      }
     },
     "decamelize": {
       "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -1513,7 +2416,10 @@
     "defaults": {
       "version": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+      }
     },
     "defined": {
       "version": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
@@ -1523,7 +2429,16 @@
     "del": {
       "version": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globby": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+        "is-path-cwd": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+        "is-path-in-cwd": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
+      }
     },
     "delayed-stream": {
       "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1551,12 +2466,18 @@
     "detect-file": {
       "version": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
       "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs-exists-sync": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz"
+      }
     },
     "detect-indent": {
       "version": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+      }
     },
     "detect-newline": {
       "version": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
@@ -1565,7 +2486,11 @@
     },
     "doctrine": {
       "version": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
-      "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM="
+      "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+      "requires": {
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+      }
     },
     "dom-walk": {
       "version": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
@@ -1584,17 +2509,29 @@
     "duplexer2": {
       "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+      }
     },
     "duplexify": {
       "version": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
       "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
       "dev": true,
+      "requires": {
+        "end-of-stream": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+        "stream-shift": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz"
+      },
       "dependencies": {
         "end-of-stream": {
           "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
           "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+          }
         },
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -1604,12 +2541,24 @@
         "once": {
           "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+          }
         },
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     },
@@ -1617,7 +2566,10 @@
       "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+      }
     },
     "ee-first": {
       "version": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1639,17 +2591,26 @@
     },
     "encoding": {
       "version": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
+      }
     },
     "end-of-stream": {
       "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
       "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
       "dev": true,
+      "requires": {
+        "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+      },
       "dependencies": {
         "once": {
           "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+          }
         }
       }
     },
@@ -1657,6 +2618,11 @@
       "version": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
       "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "memory-fs": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+        "tapable": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -1678,37 +2644,67 @@
     "errno": {
       "version": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prr": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+      }
     },
     "error-ex": {
       "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
       "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+      }
     },
     "error-stack-parser": {
       "version": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
       "integrity": "sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "stackframe": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz"
+      }
     },
     "errorhandler": {
       "version": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.3.tgz",
       "integrity": "sha1-t7cO2PNZ6duICS8tIMD4MUIK2D8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "accepts": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+      }
     },
     "es5-ext": {
       "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
       "integrity": "sha1-qoRkHU23a2Krul5F/YBey6sUAEc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
+      }
     },
     "es6-iterator": {
       "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
       "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
+        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
+      }
     },
     "es6-map": {
       "version": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz",
       "integrity": "sha1-o0sUe+IkdzpNfagHJ5TO+jYyuJc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
+        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+        "es6-set": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
+        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
+        "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
+      }
     },
     "es6-promise": {
       "version": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
@@ -1718,17 +2714,34 @@
     "es6-set": {
       "version": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
       "integrity": "sha1-lRa2dhwpZLkv9HlFYjOiR9xwfOg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
+        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
+        "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
+      }
     },
     "es6-symbol": {
       "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
       "integrity": "sha1-lEgcZV56fK2C66gy2X1UM0ltf/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
+      }
     },
     "es6-weak-map": {
       "version": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
       "integrity": "sha1-DSu9iCfrX7S6j5f7/qUNQ9sh6oE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
+        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
+      }
     },
     "escape-html": {
       "version": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1742,17 +2755,63 @@
     "escope": {
       "version": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-map": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz",
+        "es6-weak-map": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
+        "esrecurse": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
+      }
     },
     "eslint": {
       "version": "https://registry.npmjs.org/eslint/-/eslint-3.12.2.tgz",
       "integrity": "sha1-a+WpqillglKr1/kekTK6sfJvPDQ=",
       "dev": true,
+      "requires": {
+        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.20.0.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+        "escope": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+        "espree": "https://registry.npmjs.org/espree/-/espree-3.3.2.tgz",
+        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "file-entry-cache": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "globals": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
+        "ignore": "https://registry.npmjs.org/ignore/-/ignore-3.2.0.tgz",
+        "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+        "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+        "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+        "is-resolvable": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "natural-compare": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+        "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+        "pluralize": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+        "progress": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+        "require-uncached": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+        "shelljs": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.5.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+        "table": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+        "text-table": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+        "user-home": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
+      },
       "dependencies": {
         "doctrine": {
           "version": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
         },
         "esutils": {
           "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -1772,7 +2831,10 @@
         "user-home": {
           "version": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+          }
         }
       }
     },
@@ -1780,11 +2842,19 @@
       "version": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.8.0.tgz",
       "integrity": "sha1-dBq1Q4oJRTLlzhu7k11oMjVvSS0=",
       "dev": true,
+      "requires": {
+        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+        "jsx-ast-utils": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.3.5.tgz"
+      },
       "dependencies": {
         "doctrine": {
           "version": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
         },
         "esutils": {
           "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -1802,6 +2872,10 @@
       "version": "https://registry.npmjs.org/espree/-/espree-3.3.2.tgz",
       "integrity": "sha1-2/P63rTstNR3gwPlAQOz02yIuJw=",
       "dev": true,
+      "requires": {
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
+        "acorn-jsx": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
+      },
       "dependencies": {
         "acorn": {
           "version": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
@@ -1819,6 +2893,10 @@
       "version": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
       "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
       "dev": true,
+      "requires": {
+        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+      },
       "dependencies": {
         "estraverse": {
           "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
@@ -1843,11 +2921,24 @@
     "event-emitter": {
       "version": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
       "integrity": "sha1-jWPd+0z+H647MsomXExyAiIIC7U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
+      }
     },
     "event-stream": {
       "version": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE="
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "requires": {
+        "duplexer": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+        "from": "https://registry.npmjs.org/from/-/from-0.1.3.tgz",
+        "map-stream": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+        "pause-stream": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+        "split": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+        "stream-combiner": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      }
     },
     "eventemitter3": {
       "version": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
@@ -1872,21 +2963,58 @@
     "expand-brackets": {
       "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-posix-bracket": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+      }
     },
     "expand-range": {
       "version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fill-range": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
+      }
     },
     "expand-tilde": {
       "version": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
       "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+      }
     },
     "express": {
       "version": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
       "integrity": "sha1-we4/Qs3Ikfs9xlCoki1R7IR9DWY=",
+      "requires": {
+        "accepts": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+        "array-flatten": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+        "content-disposition": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
+        "content-type": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+        "cookie": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+        "cookie-signature": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+        "etag": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+        "finalhandler": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+        "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+        "merge-descriptors": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+        "methods": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+        "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+        "path-to-regexp": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+        "proxy-addr": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
+        "range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+        "send": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+        "serve-static": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
+        "type-is": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
+        "utils-merge": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+        "vary": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
+      },
       "dependencies": {
         "qs": {
           "version": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
@@ -1898,6 +3026,17 @@
       "version": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz",
       "integrity": "sha1-XMmPP1/4Ttg1+Ry/CqvQxxB0AK8=",
       "dev": true,
+      "requires": {
+        "cookie": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
+        "cookie-signature": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+        "crc": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "depd": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
+        "on-headers": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+        "uid-safe": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
+        "utils-merge": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+      },
       "dependencies": {
         "base64-url": {
           "version": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
@@ -1917,7 +3056,10 @@
         "uid-safe": {
           "version": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
           "integrity": "sha1-p/PGymSh9qXQTsDvPkw9U2cxcTc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "base64-url": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+          }
         }
       }
     },
@@ -1929,22 +3071,41 @@
     "external-editor": {
       "version": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
       "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+        "spawn-sync": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+        "tmp": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz"
+      }
     },
     "extglob": {
       "version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+      }
     },
     "extract-text-webpack-plugin": {
       "version": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-1.0.1.tgz",
       "integrity": "sha1-yVvzy6rEnclvHcbgclSfu2VMzSw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
+        "webpack-sources": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.3.tgz"
+      }
     },
     "extract-zip": {
       "version": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
       "integrity": "sha1-ksz22B73Cp+kwXRxFMzvbYaIpsQ=",
       "dev": true,
+      "requires": {
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+        "yauzl": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz"
+      },
       "dependencies": {
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
@@ -1954,7 +3115,10 @@
         "mkdirp": {
           "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+          }
         }
       }
     },
@@ -1966,7 +3130,11 @@
     "fancy-log": {
       "version": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
       "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "time-stamp": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz"
+      }
     },
     "fast-levenshtein": {
       "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -1981,11 +3149,23 @@
     "faye-websocket": {
       "version": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "websocket-driver": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz"
+      }
     },
     "fbjs": {
       "version": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.8.tgz",
       "integrity": "sha1-AvG24OoNRsJOC1Gi0k3waVY6WtY=",
+      "requires": {
+        "core-js": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+        "isomorphic-fetch": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+        "promise": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
+        "setimmediate": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+        "ua-parser-js": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz"
+      },
       "dependencies": {
         "core-js": {
           "version": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
@@ -1996,22 +3176,36 @@
     "fd-slicer": {
       "version": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pend": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
+      }
     },
     "figures": {
       "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+      }
     },
     "file-entry-cache": {
       "version": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flat-cache": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+      }
     },
     "file-loader": {
       "version": "https://registry.npmjs.org/file-loader/-/file-loader-0.9.0.tgz",
       "integrity": "sha1-HS2t3UJM5tGwfP4/eXMb7TYXq0I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz"
+      }
     },
     "filename-regex": {
       "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
@@ -2021,16 +3215,35 @@
     "fill-range": {
       "version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+        "randomatic": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+        "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+      }
     },
     "finalhandler": {
       "version": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
-      "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc="
+      "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+        "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+        "unpipe": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+      }
     },
     "find-cache-dir": {
       "version": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
       "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "commondir": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "pkg-dir": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
+      }
     },
     "find-index": {
       "version": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
@@ -2040,17 +3253,36 @@
     "find-up": {
       "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      }
     },
     "findup-sync": {
       "version": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
       "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "detect-file": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "resolve-dir": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz"
+      }
     },
     "fined": {
       "version": "https://registry.npmjs.org/fined/-/fined-1.0.2.tgz",
       "integrity": "sha1-WyhCS3YNdZiWC374SA3/itNmDpc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "expand-tilde": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+        "lodash.assignwith": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
+        "lodash.isempty": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+        "lodash.isplainobject": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+        "lodash.isstring": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+        "lodash.pick": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+        "parse-filepath": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz"
+      }
     },
     "first-chunk-stream": {
       "version": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
@@ -2066,6 +3298,12 @@
       "version": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
       "dev": true,
+      "requires": {
+        "circular-json": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
+        "del": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "write": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -2077,7 +3315,12 @@
     "flat-map": {
       "version": "https://registry.npmjs.org/flat-map/-/flat-map-0.1.0.tgz",
       "integrity": "sha1-Qw7NcEDGbuhAAYgsdZMhPLhVLAQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      }
     },
     "flatten": {
       "version": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
@@ -2097,12 +3340,21 @@
     "for-own": {
       "version": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
       "integrity": "sha1-AUm0GjkIjHUV9R6+HBOG1F+TUHI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-in": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz"
+      }
     },
     "foreman": {
       "version": "https://registry.npmjs.org/foreman/-/foreman-1.4.1.tgz",
       "integrity": "sha1-WLYfttgUxpTd8vt1sFc2BiV7EOM=",
       "dev": true,
+      "requires": {
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+        "http-proxy": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.11.3.tgz",
+        "mu2": "https://registry.npmjs.org/mu2/-/mu2-0.5.21.tgz",
+        "shell-quote": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz"
+      },
       "dependencies": {
         "commander": {
           "version": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
@@ -2112,7 +3364,11 @@
         "http-proxy": {
           "version": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.11.3.tgz",
           "integrity": "sha1-GRXciIdR4qa/PCq/yxgI+obHI1M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "eventemitter3": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+            "requires-port": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.1.tgz"
+          }
         },
         "requires-port": {
           "version": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.1.tgz",
@@ -2134,7 +3390,12 @@
     "form-data": {
       "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
       "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz"
+      }
     },
     "forwarded": {
       "version": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
@@ -2143,7 +3404,11 @@
     "foundation-sites": {
       "version": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.2.4.tgz",
       "integrity": "sha1-VUdGyfPVBb1WRrTcwD+KmUHmf3s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jquery": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
+        "what-input": "https://registry.npmjs.org/what-input/-/what-input-2.1.1.tgz"
+      }
     },
     "fresh": {
       "version": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
@@ -2157,6 +3422,10 @@
       "version": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -2166,7 +3435,16 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     },
@@ -2179,6 +3457,11 @@
       "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
       "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "jsonfile": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+        "klaw": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -2190,7 +3473,10 @@
     "fs-mode": {
       "version": "https://registry.npmjs.org/fs-mode/-/fs-mode-1.0.1.tgz",
       "integrity": "sha1-cxAvQKoaJSId2g6qkGYW1toIJVo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cbify": "https://registry.npmjs.org/cbify/-/cbify-1.0.0.tgz"
+      }
     },
     "fs.realpath": {
       "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2202,6 +3488,10 @@
       "integrity": "sha1-hTfz8SJyZ4dltP1lKMDx9m+PRVg=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "nan": "https://registry.npmjs.org/nan/-/nan-2.5.0.tgz",
+        "node-pre-gyp": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz"
+      },
       "dependencies": {
         "abbrev": {
           "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -2230,7 +3520,11 @@
           "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
           "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "delegates": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          }
         },
         "asn1": {
           "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -2271,22 +3565,35 @@
           "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
           "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+          }
         },
         "block-stream": {
           "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+          }
         },
         "boom": {
           "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+          }
         },
         "brace-expansion": {
           "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+            "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+          }
         },
         "buffer-shims": {
           "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
@@ -2304,6 +3611,13 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+          },
           "dependencies": {
             "supports-color": {
               "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -2321,13 +3635,19 @@
         "combined-stream": {
           "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+          }
         },
         "commander": {
           "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+          }
         },
         "concat-map": {
           "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2348,13 +3668,19 @@
           "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+          }
         },
         "dashdash": {
           "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -2368,7 +3694,10 @@
           "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+          }
         },
         "deep-extend": {
           "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
@@ -2391,7 +3720,10 @@
           "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
           "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+          }
         },
         "escape-string-regexp": {
           "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -2420,7 +3752,12 @@
           "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
           "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz"
+          }
         },
         "fs.realpath": {
           "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2430,19 +3767,41 @@
         "fstream": {
           "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
           "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
+          }
         },
         "fstream-ignore": {
           "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
           "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+          }
         },
         "gauge": {
           "version": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz",
           "integrity": "sha1-Fc7MMbAtBTRaXWsOFxzbOtIwd3Q=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "aproba": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
+            "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+            "has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+            "wide-align": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
+          }
         },
         "generate-function": {
           "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
@@ -2454,13 +3813,19 @@
           "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
           "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+          }
         },
         "getpass": {
           "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
           "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -2473,7 +3838,15 @@
         "glob": {
           "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
         },
         "graceful-fs": {
           "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -2490,13 +3863,22 @@
           "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+            "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+          }
         },
         "has-ansi": {
           "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+          }
         },
         "has-unicode": {
           "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -2508,7 +3890,13 @@
           "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+            "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+            "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+            "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+          }
         },
         "hoek": {
           "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
@@ -2519,12 +3907,21 @@
           "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+            "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+            "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz"
+          }
         },
         "inflight": {
           "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+          }
         },
         "inherits": {
           "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -2540,13 +3937,22 @@
         "is-fullwidth-code-point": {
           "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+          }
         },
         "is-my-json-valid": {
           "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
           "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+            "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+            "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          }
         },
         "is-property": {
           "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -2575,7 +3981,10 @@
           "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
           "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+          }
         },
         "jsbn": {
           "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
@@ -2605,7 +4014,12 @@
           "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
           "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+            "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+          }
         },
         "mime-db": {
           "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
@@ -2615,12 +4029,18 @@
         "mime-types": {
           "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
           "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
+          }
         },
         "minimatch": {
           "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+          }
         },
         "minimist": {
           "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
@@ -2630,7 +4050,10 @@
         "mkdirp": {
           "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+          }
         },
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -2642,19 +4065,39 @@
           "version": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz",
           "integrity": "sha1-/EUrN25zGbPSVfXzSFPvb9j+H9U=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+            "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+            "rc": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+            "request": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+            "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+            "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+            "tar-pack": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz"
+          }
         },
         "nopt": {
           "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+          }
         },
         "npmlog": {
           "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
           "integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+            "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+            "gauge": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz",
+            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+          }
         },
         "number-is-nan": {
           "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -2676,7 +4119,10 @@
         "once": {
           "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+          }
         },
         "path-is-absolute": {
           "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -2693,7 +4139,10 @@
           "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+          }
         },
         "process-nextick-args": {
           "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -2717,6 +4166,12 @@
           "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "deep-extend": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+            "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+          },
           "dependencies": {
             "minimist": {
               "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -2730,18 +4185,52 @@
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         },
         "request": {
           "version": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
           "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+            "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
+            "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+            "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+            "extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+            "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+            "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+            "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+            "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+            "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+            "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "qs": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
+            "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+            "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+            "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+          }
         },
         "rimraf": {
           "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
           "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+          }
         },
         "semver": {
           "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -2765,13 +4254,27 @@
           "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+          }
         },
         "sshpk": {
           "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
           "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+            "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+            "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+            "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+            "jodid25519": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+            "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+            "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -2781,14 +4284,19 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
         "string-width": {
           "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
         "stringstream": {
@@ -2800,7 +4308,10 @@
         "strip-ansi": {
           "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+          }
         },
         "strip-json-comments": {
           "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
@@ -2817,25 +4328,52 @@
         "tar": {
           "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+            "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+          }
         },
         "tar-pack": {
           "version": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
           "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+            "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+            "fstream-ignore": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+            "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+            "uid-number": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+          },
           "dependencies": {
             "once": {
               "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
               "dev": true,
-              "optional": true
+              "optional": true,
+              "requires": {
+                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+              }
             },
             "readable-stream": {
               "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
               "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
               "dev": true,
-              "optional": true
+              "optional": true,
+              "requires": {
+                "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+              }
             }
           }
         },
@@ -2843,7 +4381,10 @@
           "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
           "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+          }
         },
         "tunnel-agent": {
           "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
@@ -2878,13 +4419,19 @@
           "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
           "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+          }
         },
         "wide-align": {
           "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
           "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+          }
         },
         "wrappy": {
           "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -2903,6 +4450,12 @@
       "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
       "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -2919,12 +4472,26 @@
     "gauge": {
       "version": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
       "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "aproba": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
+        "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+        "has-color": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+        "has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+        "wide-align": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
+      }
     },
     "gaze": {
       "version": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
       "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globule": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz"
+      }
     },
     "generate-function": {
       "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
@@ -2934,7 +4501,10 @@
     "generate-object-property": {
       "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+      }
     },
     "get-caller-file": {
       "version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -2954,6 +4524,9 @@
       "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
       "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
       "dev": true,
+      "requires": {
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -2965,69 +4538,131 @@
     "glob": {
       "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+      }
     },
     "glob-base": {
       "version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+      }
     },
     "glob-parent": {
       "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+      }
     },
     "glob-stream": {
       "version": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
       "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
       "dev": true,
+      "requires": {
+        "glob": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+        "glob2base": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+        "ordered-read-streams": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+        "unique-stream": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
+      },
       "dependencies": {
         "glob": {
           "version": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+          }
         },
         "minimatch": {
           "version": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+          }
         },
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
         },
         "through2": {
           "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          }
         }
       }
     },
     "glob-watcher": {
       "version": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
       "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "gaze": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz"
+      }
     },
     "glob2base": {
       "version": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-index": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
+      }
     },
     "global": {
       "version": "https://registry.npmjs.org/global/-/global-4.3.1.tgz",
       "integrity": "sha1-X3V5CMfLq85U84auRA4R4mt5Ft8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "min-document": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+        "process": "https://registry.npmjs.org/process/-/process-0.5.2.tgz"
+      }
     },
     "global-modules": {
       "version": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
       "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "global-prefix": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+        "is-windows": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
+      }
     },
     "global-prefix": {
       "version": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
       "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+        "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+        "is-windows": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.2.12.tgz"
+      }
     },
     "globals": {
       "version": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
@@ -3037,17 +4672,35 @@
     "globby": {
       "version": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      }
     },
     "globule": {
       "version": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
       "dev": true,
+      "requires": {
+        "glob": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
+      },
       "dependencies": {
         "glob": {
           "version": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
+          }
         },
         "graceful-fs": {
           "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
@@ -3067,19 +4720,29 @@
         "minimatch": {
           "version": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+            "sigmund": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+          }
         }
       }
     },
     "glogg": {
       "version": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
       "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sparkles": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+      }
     },
     "graceful-fs": {
       "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
       "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "natives": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz"
+      }
     },
     "graceful-readlink": {
       "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
@@ -3095,6 +4758,21 @@
       "version": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
       "dev": true,
+      "requires": {
+        "archy": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "deprecated": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "interpret": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
+        "liftoff": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "orchestrator": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
+        "pretty-hrtime": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+        "tildify": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+        "v8flags": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
+        "vinyl-fs": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz"
+      },
       "dependencies": {
         "minimist": {
           "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -3106,17 +4784,36 @@
     "gulp-autoprefixer": {
       "version": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-3.1.1.tgz",
       "integrity": "sha1-dSMAUc0NFxND14O36bXREg7u+bA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "autoprefixer": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.6.1.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl-sourcemaps-apply": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz"
+      }
     },
     "gulp-babel": {
       "version": "https://registry.npmjs.org/gulp-babel/-/gulp-babel-6.1.2.tgz",
       "integrity": "sha1-fAF25Lo/JExgWIoMSzIKRdGt784=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-6.21.0.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+        "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl-sourcemaps-apply": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz"
+      }
     },
     "gulp-clone": {
       "version": "https://registry.npmjs.org/gulp-clone/-/gulp-clone-1.0.0.tgz",
       "integrity": "sha1-mubGVr2cTzae6AXu9WV4a8gQBbA=",
       "dev": true,
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
@@ -3131,29 +4828,57 @@
         "chalk": {
           "version": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+          }
         },
         "dateformat": {
           "version": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+            "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
+          }
         },
         "gulp-util": {
           "version": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
           "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
           "dev": true,
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+            "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+            "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+            "multipipe": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+            "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz"
+          },
           "dependencies": {
             "through2": {
               "version": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                "xtend": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+              }
             }
           }
         },
         "has-ansi": {
           "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+          }
         },
         "lodash._reinterpolate": {
           "version": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
@@ -3163,22 +4888,45 @@
         "lodash.escape": {
           "version": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
           "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._escapehtmlchar": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+            "lodash._reunescapedhtml": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+            "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+          }
         },
         "lodash.keys": {
           "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._isnative": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+            "lodash._shimkeys": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+            "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+          }
         },
         "lodash.template": {
           "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
           "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._escapestringchar": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+            "lodash.defaults": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+            "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+            "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+            "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
+            "lodash.values": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
+          }
         },
         "lodash.templatesettings": {
           "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
           "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+            "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz"
+          }
         },
         "minimist": {
           "version": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
@@ -3188,12 +4936,21 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
         },
         "strip-ansi": {
           "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+          }
         },
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
@@ -3204,18 +4961,28 @@
           "version": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
           "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
           "dev": true,
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
+          },
           "dependencies": {
             "xtend": {
               "version": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "object-keys": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+              }
             }
           }
         },
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
           "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+          }
         },
         "xtend": {
           "version": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
@@ -3228,6 +4995,9 @@
       "version": "https://registry.npmjs.org/gulp-cond/-/gulp-cond-1.0.0.tgz",
       "integrity": "sha1-mYDDzcr6m8TNMKuHEIesE1lVtVg=",
       "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -3237,39 +5007,82 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     },
     "gulp-connect": {
       "version": "https://registry.npmjs.org/gulp-connect/-/gulp-connect-4.2.0.tgz",
       "integrity": "sha1-qeoRzty8XBOhY4rH9sgeWBjD1V4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "connect": "https://registry.npmjs.org/connect/-/connect-2.30.2.tgz",
+        "connect-livereload": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.5.4.tgz",
+        "event-stream": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "http2": "https://registry.npmjs.org/http2/-/http2-3.3.6.tgz",
+        "tiny-lr": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.2.1.tgz"
+      }
     },
     "gulp-cssnano": {
       "version": "https://registry.npmjs.org/gulp-cssnano/-/gulp-cssnano-2.1.2.tgz",
       "integrity": "sha1-4IoJdx7FRUpUnxoAW90lbLjl4KM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cssnano": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+        "vinyl-sourcemaps-apply": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz"
+      }
     },
     "gulp-env": {
       "version": "https://registry.npmjs.org/gulp-env/-/gulp-env-0.4.0.tgz",
       "integrity": "sha1-g3BkaUmjJJPcBtrZSgZDKW+q2+g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
     },
     "gulp-eslint": {
       "version": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-3.0.1.tgz",
       "integrity": "sha1-BOV+PhjGl0JnwSz2hV3HF9SjE70=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bufferstreams": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.1.tgz",
+        "eslint": "https://registry.npmjs.org/eslint/-/eslint-3.12.2.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz"
+      }
     },
     "gulp-filter": {
       "version": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-4.0.0.tgz",
       "integrity": "sha1-OV9YolbFWc254NFX8cqvUkijjcs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "multimatch": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+        "streamfilter": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.5.tgz"
+      }
     },
     "gulp-gzip": {
       "version": "https://registry.npmjs.org/gulp-gzip/-/gulp-gzip-1.4.0.tgz",
       "integrity": "sha1-X/jf+DfKwuvCyJdD3ArHbivl5sI=",
       "dev": true,
+      "requires": {
+        "bytes": "https://registry.npmjs.org/bytes/-/bytes-0.3.0.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+        "stream-to-array": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-1.0.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
@@ -3289,29 +5102,57 @@
         "chalk": {
           "version": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+          }
         },
         "dateformat": {
           "version": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+            "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
+          }
         },
         "gulp-util": {
           "version": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
           "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
           "dev": true,
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+            "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+            "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+            "multipipe": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+            "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz"
+          },
           "dependencies": {
             "through2": {
               "version": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                "xtend": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+              }
             }
           }
         },
         "has-ansi": {
           "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+          }
         },
         "lodash._reinterpolate": {
           "version": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
@@ -3321,22 +5162,45 @@
         "lodash.escape": {
           "version": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
           "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._escapehtmlchar": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+            "lodash._reunescapedhtml": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+            "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+          }
         },
         "lodash.keys": {
           "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._isnative": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+            "lodash._shimkeys": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+            "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+          }
         },
         "lodash.template": {
           "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
           "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._escapestringchar": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+            "lodash.defaults": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+            "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+            "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+            "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
+            "lodash.values": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
+          }
         },
         "lodash.templatesettings": {
           "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
           "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+            "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz"
+          }
         },
         "minimist": {
           "version": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
@@ -3346,12 +5210,21 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
         },
         "strip-ansi": {
           "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+          }
         },
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
@@ -3362,18 +5235,28 @@
           "version": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
           "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
           "dev": true,
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
+          },
           "dependencies": {
             "xtend": {
               "version": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "object-keys": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+              }
             }
           }
         },
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
           "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+          }
         },
         "xtend": {
           "version": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
@@ -3385,22 +5268,61 @@
     "gulp-if": {
       "version": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
       "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "gulp-match": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+        "ternary-stream": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
     },
     "gulp-jasmine": {
       "version": "https://registry.npmjs.org/gulp-jasmine/-/gulp-jasmine-2.4.2.tgz",
       "integrity": "sha1-Wn9H4nNww2GawKKkQr45lnFAnbM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "jasmine": "https://registry.npmjs.org/jasmine/-/jasmine-2.5.2.tgz",
+        "jasmine-terminal-reporter": "https://registry.npmjs.org/jasmine-terminal-reporter/-/jasmine-terminal-reporter-1.0.2.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
     },
     "gulp-jasmine-browser": {
       "version": "https://registry.npmjs.org/gulp-jasmine-browser/-/gulp-jasmine-browser-1.7.1.tgz",
       "integrity": "sha1-6qzbpzMkuM3bdn4wecX1wwZF+yw=",
       "dev": true,
+      "requires": {
+        "babel-polyfill": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.20.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "express": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
+        "flat-map": "https://registry.npmjs.org/flat-map/-/flat-map-0.1.0.tgz",
+        "jasmine-core": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.5.2.tgz",
+        "jasmine-json-stream-reporter": "https://registry.npmjs.org/jasmine-json-stream-reporter/-/jasmine-json-stream-reporter-0.2.0.tgz",
+        "jasmine-profile-reporter": "https://registry.npmjs.org/jasmine-profile-reporter/-/jasmine-profile-reporter-0.0.2.tgz",
+        "jasmine-terminal-reporter": "https://registry.npmjs.org/jasmine-terminal-reporter/-/jasmine-terminal-reporter-1.0.2.tgz",
+        "lazypipe": "https://registry.npmjs.org/lazypipe/-/lazypipe-1.0.1.tgz",
+        "lodash.once": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+        "mime": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+        "portfinder": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.10.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-5.2.1.tgz",
+        "serve-favicon": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.2.tgz",
+        "sourcemapped-stacktrace": "https://registry.npmjs.org/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.5.tgz",
+        "split2": "https://registry.npmjs.org/split2/-/split2-2.1.1.tgz",
+        "thenify": "https://registry.npmjs.org/thenify/-/thenify-3.2.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "through2-reduce": "https://registry.npmjs.org/through2-reduce/-/through2-reduce-1.1.1.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
+      },
       "dependencies": {
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+          }
         }
       }
     },
@@ -3408,6 +5330,14 @@
       "version": "https://registry.npmjs.org/gulp-livereload/-/gulp-livereload-3.8.1.tgz",
       "integrity": "sha1-APdEstdJ0+njdGWJyKRKysd5tQ8=",
       "dev": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "event-stream": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+        "mini-lr": "https://registry.npmjs.org/mini-lr/-/mini-lr-0.1.9.tgz"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
@@ -3422,22 +5352,40 @@
         "chalk": {
           "version": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+          }
         },
         "has-ansi": {
           "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+          }
         },
         "lodash.assign": {
           "version": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
           "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._baseassign": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+            "lodash._createassigner": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+            "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+          }
         },
         "strip-ansi": {
           "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+          }
         },
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
@@ -3449,27 +5397,52 @@
     "gulp-load-plugins": {
       "version": "https://registry.npmjs.org/gulp-load-plugins/-/gulp-load-plugins-1.4.0.tgz",
       "integrity": "sha1-gvqwNxXs8YOKlY7GQ6TXQnTd/s4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+        "fancy-log": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+        "findup-sync": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+        "gulplog": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+        "has-gulplog": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz"
+      }
     },
     "gulp-match": {
       "version": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
       "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+      }
     },
     "gulp-plumber": {
       "version": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.1.0.tgz",
       "integrity": "sha1-8SF2wtBCL2AwbCQv/2oBo5T6ugk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
     },
     "gulp-process-env": {
       "version": "https://registry.npmjs.org/gulp-process-env/-/gulp-process-env-0.0.1.tgz",
       "integrity": "sha1-VKhjFolM11ME7yW/NDJdV4m1keY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "through2-spy": "https://registry.npmjs.org/through2-spy/-/through2-spy-2.0.0.tgz"
+      }
     },
     "gulp-progeny": {
       "version": "https://registry.npmjs.org/gulp-progeny/-/gulp-progeny-0.3.2.tgz",
       "integrity": "sha1-v4Ihqs9/3c3M2ijMj3fOlwU72Lc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "progeny": "https://registry.npmjs.org/progeny/-/progeny-0.7.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
     },
     "gulp-rename": {
       "version": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
@@ -3480,6 +5453,16 @@
       "version": "https://registry.npmjs.org/gulp-rev/-/gulp-rev-7.1.2.tgz",
       "integrity": "sha1-XhfMIp9rRcdCVviK0/LT6aMwWCk=",
       "dev": true,
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "modify-filename": "https://registry.npmjs.org/modify-filename/-/modify-filename-1.1.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+        "rev-hash": "https://registry.npmjs.org/rev-hash/-/rev-hash-1.0.0.tgz",
+        "rev-path": "https://registry.npmjs.org/rev-path/-/rev-path-1.0.0.tgz",
+        "sort-keys": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl-file": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-1.3.0.tgz"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -3489,22 +5472,40 @@
         "strip-bom": {
           "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+          }
         },
         "strip-bom-stream": {
           "version": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
           "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "first-chunk-stream": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+          }
         },
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+          }
         },
         "vinyl-file": {
           "version": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-1.3.0.tgz",
           "integrity": "sha1-qgVjTTqGe6kUR77bs0r8sm9E9uc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "strip-bom-stream": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+            "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
+          }
         }
       }
     },
@@ -3512,6 +5513,11 @@
       "version": "https://registry.npmjs.org/gulp-rev-css-url/-/gulp-rev-css-url-0.1.0.tgz",
       "integrity": "sha1-GMOQ4AeYL2QrJp023qmDgvZ95fU=",
       "dev": true,
+      "requires": {
+        "crypto": "https://registry.npmjs.org/crypto/-/crypto-0.0.3.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
@@ -3526,29 +5532,57 @@
         "chalk": {
           "version": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+          }
         },
         "dateformat": {
           "version": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+            "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
+          }
         },
         "gulp-util": {
           "version": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
           "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
           "dev": true,
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+            "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+            "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+            "multipipe": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+            "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz"
+          },
           "dependencies": {
             "through2": {
               "version": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                "xtend": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+              }
             }
           }
         },
         "has-ansi": {
           "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+          }
         },
         "lodash._reinterpolate": {
           "version": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
@@ -3558,22 +5592,45 @@
         "lodash.escape": {
           "version": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
           "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._escapehtmlchar": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+            "lodash._reunescapedhtml": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+            "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+          }
         },
         "lodash.keys": {
           "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._isnative": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+            "lodash._shimkeys": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+            "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+          }
         },
         "lodash.template": {
           "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
           "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._escapestringchar": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+            "lodash.defaults": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+            "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+            "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+            "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
+            "lodash.values": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
+          }
         },
         "lodash.templatesettings": {
           "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
           "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+            "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz"
+          }
         },
         "minimist": {
           "version": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
@@ -3583,12 +5640,21 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
         },
         "strip-ansi": {
           "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+          }
         },
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
@@ -3599,18 +5665,28 @@
           "version": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
           "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
           "dev": true,
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
+          },
           "dependencies": {
             "xtend": {
               "version": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "object-keys": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+              }
             }
           }
         },
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
           "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+          }
         },
         "xtend": {
           "version": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
@@ -3622,17 +5698,42 @@
     "gulp-sass": {
       "version": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-2.3.2.tgz",
       "integrity": "sha1-grerkP6QLNw0wE8YDZLyw0kC3VI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "lodash.clonedeep": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+        "node-sass": "https://registry.npmjs.org/node-sass/-/node-sass-3.13.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl-sourcemaps-apply": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz"
+      }
     },
     "gulp-shell": {
       "version": "https://registry.npmjs.org/gulp-shell/-/gulp-shell-0.5.2.tgz",
       "integrity": "sha1-pJWcoGUa0ce7/nCy0K27tOGuqY0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
     },
     "gulp-sourcemaps": {
       "version": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.9.1.tgz",
       "integrity": "sha1-gKwtOEXRPmjdliUk2KlnpECwt1M=",
       "dev": true,
+      "requires": {
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
+        "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
+        "css": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+        "debug-fabulous": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
+        "detect-newline": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
+      },
       "dependencies": {
         "acorn": {
           "version": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
@@ -3647,12 +5748,20 @@
         "strip-bom": {
           "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+          }
         },
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+          }
         }
       }
     },
@@ -3660,16 +5769,31 @@
       "version": "https://registry.npmjs.org/gulp-tap/-/gulp-tap-0.1.3.tgz",
       "integrity": "sha1-Eg3KKQHnb7hNXLStXzfK0BVjYeQ=",
       "dev": true,
+      "requires": {
+        "event-stream": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz"
+      },
       "dependencies": {
         "event-stream": {
           "version": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
           "integrity": "sha1-tMVAAS0P4UmEIPPYlGAI22OTw3o=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "duplexer": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+            "from": "https://registry.npmjs.org/from/-/from-0.1.3.tgz",
+            "map-stream": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+            "pause-stream": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "split": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
+            "stream-combiner": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+            "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+          }
         },
         "split": {
           "version": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
           "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+          }
         }
       }
     },
@@ -3677,6 +5801,26 @@
       "version": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "dev": true,
+      "requires": {
+        "array-differ": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+        "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+        "beeper": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+        "fancy-log": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+        "gulplog": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+        "has-gulplog": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+        "lodash._reescape": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+        "lodash._reevaluate": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+        "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "multipipe": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+        "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
+      },
       "dependencies": {
         "minimist": {
           "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -3694,6 +5838,9 @@
       "version": "https://registry.npmjs.org/gulp-wait/-/gulp-wait-0.0.2.tgz",
       "integrity": "sha1-7Ov/REbhoNU3yx3Hc9vUWB0X+y0=",
       "dev": true,
+      "requires": {
+        "map-stream": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.4.tgz"
+      },
       "dependencies": {
         "map-stream": {
           "version": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.4.tgz",
@@ -3706,11 +5853,27 @@
       "version": "https://registry.npmjs.org/gulp-watch/-/gulp-watch-4.3.11.tgz",
       "integrity": "sha1-Fi/FY96fx3DpH5p845VVE6mhGMA=",
       "dev": true,
+      "requires": {
+        "anymatch": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+        "chokidar": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+        "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+        "slash": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+        "vinyl-file": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz"
+      },
       "dependencies": {
         "glob-parent": {
           "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+            "path-dirname": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz"
+          }
         },
         "is-extglob": {
           "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3720,7 +5883,10 @@
         "is-glob": {
           "version": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
+          }
         },
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -3730,34 +5896,63 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         },
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+          }
         }
       }
     },
     "gulplog": {
       "version": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glogg": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
+      }
     },
     "har-validator": {
       "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+        "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      }
     },
     "has": {
       "version": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+      }
     },
     "has-ansi": {
       "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+      }
     },
     "has-color": {
       "version": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
@@ -3772,7 +5967,10 @@
     "has-gulplog": {
       "version": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sparkles": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+      }
     },
     "has-unicode": {
       "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -3782,12 +5980,22 @@
     "hasha": {
       "version": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      }
     },
     "hawk": {
       "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+        "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+        "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+      }
     },
     "hoek": {
       "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
@@ -3802,12 +6010,19 @@
     "home-or-tmp": {
       "version": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+        "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+      }
     },
     "homedir-polyfill": {
       "version": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "parse-passwd": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz"
+      }
     },
     "hosted-git-info": {
       "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
@@ -3826,17 +6041,32 @@
     },
     "http-errors": {
       "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
-      "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A="
+      "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "setprototypeof": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+      }
     },
     "http-proxy": {
       "version": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
       "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "eventemitter3": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+        "requires-port": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+      }
     },
     "http-proxy-middleware": {
       "version": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.3.tgz",
       "integrity": "sha1-lAOCFHFJuFYIT1U0dS1bWoFozR0=",
       "dev": true,
+      "requires": {
+        "http-proxy": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
+      },
       "dependencies": {
         "is-extglob": {
           "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3846,14 +6076,22 @@
         "is-glob": {
           "version": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
+          }
         }
       }
     },
     "http-signature": {
       "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+        "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+        "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz"
+      }
     },
     "http2": {
       "version": "https://registry.npmjs.org/http2/-/http2-3.3.6.tgz",
@@ -3893,7 +6131,10 @@
     "immutability-helper": {
       "version": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.1.0.tgz",
       "integrity": "sha1-NaS8d+TesSC4w3B5qYD5utg0ui0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz"
+      }
     },
     "imurmurhash": {
       "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3908,7 +6149,10 @@
     "indent-string": {
       "version": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+      }
     },
     "indexes-of": {
       "version": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
@@ -3923,7 +6167,11 @@
     "inflight": {
       "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+      }
     },
     "inherits": {
       "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -3937,12 +6185,31 @@
     "inline-style-prefixer": {
       "version": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz",
       "integrity": "sha1-wVPH6I/YT+9cYC6VqBaLJ3BnH+c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bowser": "https://registry.npmjs.org/bowser/-/bowser-1.6.0.tgz",
+        "hyphenate-style-name": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz"
+      }
     },
     "inquirer": {
       "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "cli-cursor": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+        "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+        "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "readline2": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+        "run-async": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+        "rx-lite": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      }
     },
     "interpret": {
       "version": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
@@ -3952,7 +6219,10 @@
     "invariant": {
       "version": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz"
+      }
     },
     "invert-kv": {
       "version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -3966,7 +6236,11 @@
     "is-absolute": {
       "version": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
       "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-relative": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+        "is-windows": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
+      }
     },
     "is-absolute-url": {
       "version": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
@@ -3981,7 +6255,10 @@
     "is-binary-path": {
       "version": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "binary-extensions": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz"
+      }
     },
     "is-buffer": {
       "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
@@ -3991,7 +6268,10 @@
     "is-builtin-module": {
       "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+      }
     },
     "is-dotfile": {
       "version": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
@@ -4001,7 +6281,10 @@
     "is-equal-shallow": {
       "version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+      }
     },
     "is-extendable": {
       "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -4016,27 +6299,45 @@
     "is-finite": {
       "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+      }
     },
     "is-glob": {
       "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+      }
     },
     "is-my-json-valid": {
       "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
       "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+        "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+        "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      }
     },
     "is-number": {
       "version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz"
+      }
     },
     "is-path-cwd": {
       "version": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
@@ -4046,12 +6347,18 @@
     "is-path-in-cwd": {
       "version": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-path-inside": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+      }
     },
     "is-path-inside": {
       "version": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
+      }
     },
     "is-plain-obj": {
       "version": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -4081,12 +6388,18 @@
     "is-relative": {
       "version": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
       "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-unc-path": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz"
+      }
     },
     "is-resolvable": {
       "version": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tryit": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
+      }
     },
     "is-stream": {
       "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -4095,7 +6408,10 @@
     "is-svg": {
       "version": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "html-comment-regex": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz"
+      }
     },
     "is-typedarray": {
       "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -4105,7 +6421,10 @@
     "is-unc-path": {
       "version": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
       "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "unc-path-regex": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz"
+      }
     },
     "is-utf8": {
       "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -4130,6 +6449,9 @@
       "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
       "dev": true,
+      "requires": {
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4140,7 +6462,11 @@
     },
     "isomorphic-fetch": {
       "version": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk="
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+        "whatwg-fetch": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.1.tgz"
+      }
     },
     "isstream": {
       "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -4150,12 +6476,12 @@
     "jasmine": {
       "version": "https://registry.npmjs.org/jasmine/-/jasmine-2.5.2.tgz",
       "integrity": "sha1-YoPO9whcCVzCXWUelU3wBPfj5CE=",
-      "dev": true
-    },
-    "jasmine_dom_matchers": {
-      "version": "https://registry.npmjs.org/jasmine_dom_matchers/-/jasmine_dom_matchers-1.4.0.tgz",
-      "integrity": "sha1-d3cDc9xxiQC79HtH23B1SNRo0BI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "exit": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "jasmine-core": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.5.2.tgz"
+      }
     },
     "jasmine-ajax": {
       "version": "https://registry.npmjs.org/jasmine-ajax/-/jasmine-ajax-3.3.1.tgz",
@@ -4171,6 +6497,10 @@
       "version": "https://registry.npmjs.org/jasmine-json-stream-reporter/-/jasmine-json-stream-reporter-0.2.0.tgz",
       "integrity": "sha1-TEDH/GAz28EZSu+H270umiQdNBU=",
       "dev": true,
+      "requires": {
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "uuid": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
+      },
       "dependencies": {
         "uuid": {
           "version": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
@@ -4187,13 +6517,25 @@
     "jasmine-terminal-reporter": {
       "version": "https://registry.npmjs.org/jasmine-terminal-reporter/-/jasmine-terminal-reporter-1.0.2.tgz",
       "integrity": "sha1-049Jar5DoI7dwNGM3fFM0RjZ5E4=",
+      "dev": true,
+      "requires": {
+        "indent-string": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+        "pluralize": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
+      }
+    },
+    "jasmine_dom_matchers": {
+      "version": "https://registry.npmjs.org/jasmine_dom_matchers/-/jasmine_dom_matchers-1.4.0.tgz",
+      "integrity": "sha1-d3cDc9xxiQC79HtH23B1SNRo0BI=",
       "dev": true
     },
     "jodid25519": {
       "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
       "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+      }
     },
     "jquery": {
       "version": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
@@ -4212,7 +6554,11 @@
     "js-yaml": {
       "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+        "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+      }
     },
     "jsbn": {
       "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
@@ -4233,7 +6579,10 @@
     "json-stable-stringify": {
       "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+      }
     },
     "json-stringify-safe": {
       "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -4243,7 +6592,10 @@
     "json2mq": {
       "version": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
       "integrity": "sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "string-convert": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz"
+      }
     },
     "json5": {
       "version": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
@@ -4254,6 +6606,9 @@
       "version": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -4276,12 +6631,21 @@
     "jsprim": {
       "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
       "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+        "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+        "verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+      }
     },
     "jsx-ast-utils": {
       "version": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.3.5.tgz",
       "integrity": "sha1-m6YpcZjZ91RZTWLllJb/uSN3jdQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "acorn-jsx": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+      }
     },
     "kew": {
       "version": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
@@ -4296,12 +6660,18 @@
     "kind-of": {
       "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
       "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
+      }
     },
     "klaw": {
       "version": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -4318,18 +6688,24 @@
     },
     "lazy-debug-legacy": {
       "version": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-      "integrity": "sha1-U3cWwHduTPeePtG2IfdljCkRsbE=",
+      "integrity": "sha1-gswqb03PNvrPDHp5RoV7/2KCisc=",
       "dev": true
     },
     "lazypipe": {
       "version": "https://registry.npmjs.org/lazypipe/-/lazypipe-1.0.1.tgz",
       "integrity": "sha1-FHGu9rN6NA1Rw030Rpnc7wZMGUA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "stream-combiner": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+      }
     },
     "lazystream": {
       "version": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4339,24 +6715,51 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     },
     "lcid": {
       "version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "invert-kv": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+      }
     },
     "levn": {
       "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+      }
     },
     "liftoff": {
       "version": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
       "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+        "findup-sync": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+        "fined": "https://registry.npmjs.org/fined/-/fined-1.0.2.tgz",
+        "flagged-respawn": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
+        "lodash.isplainobject": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+        "lodash.isstring": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+        "lodash.mapvalues": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+        "rechoir": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz"
+      }
     },
     "livereload-js": {
       "version": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
@@ -4367,6 +6770,13 @@
       "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -4376,14 +6786,23 @@
         "strip-bom": {
           "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+          }
         }
       }
     },
     "loader-utils": {
       "version": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
       "integrity": "sha1-8IYyBm7YKCg13/iN+1JwR2Wt7m0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "big.js": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+        "emojis-list": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+        "json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+      }
     },
     "lodash": {
       "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
@@ -4393,7 +6812,11 @@
     "lodash._baseassign": {
       "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+      }
     },
     "lodash._basecopy": {
       "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
@@ -4418,17 +6841,29 @@
     "lodash._createassigner": {
       "version": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
       "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._bindcallback": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+        "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+        "lodash.restparam": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+      }
     },
     "lodash._createcompounder": {
       "version": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
       "integrity": "sha1-XdLLVTctbnDg4jkvsjBNZjEJEHU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash.deburr": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.2.0.tgz",
+        "lodash.words": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.2.0.tgz"
+      }
     },
     "lodash._escapehtmlchar": {
       "version": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
       "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._htmlescapes": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+      }
     },
     "lodash._escapestringchar": {
       "version": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
@@ -4479,11 +6914,20 @@
       "version": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
       "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
       "dev": true,
+      "requires": {
+        "lodash._htmlescapes": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
+        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+      },
       "dependencies": {
         "lodash.keys": {
           "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._isnative": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+            "lodash._shimkeys": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+            "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+          }
         }
       }
     },
@@ -4495,7 +6939,10 @@
     "lodash._shimkeys": {
       "version": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
       "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+      }
     },
     "lodash.assign": {
       "version": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
@@ -4528,24 +6975,39 @@
     "lodash.deburr": {
       "version": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.2.0.tgz",
       "integrity": "sha1-baj1QzSjZqfPTEx2742Aqhs2XtU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._root": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
+      }
     },
     "lodash.defaults": {
       "version": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
       "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
       "dev": true,
+      "requires": {
+        "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+      },
       "dependencies": {
         "lodash.keys": {
           "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._isnative": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+            "lodash._shimkeys": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+            "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+          }
         }
       }
     },
     "lodash.escape": {
       "version": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._root": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
+      }
     },
     "lodash.flow": {
       "version": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
@@ -4575,7 +7037,10 @@
     "lodash.isobject": {
       "version": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
       "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+      }
     },
     "lodash.isplainobject": {
       "version": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -4590,7 +7055,12 @@
     "lodash.keys": {
       "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+        "lodash.isarguments": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+        "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+      }
     },
     "lodash.mapvalues": {
       "version": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
@@ -4630,12 +7100,27 @@
     "lodash.template": {
       "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+        "lodash._basetostring": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+        "lodash._basevalues": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+        "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+        "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+        "lodash.restparam": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+        "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
+      }
     },
     "lodash.templatesettings": {
       "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+        "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz"
+      }
     },
     "lodash.throttle": {
       "version": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
@@ -4646,18 +7131,29 @@
       "version": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
       "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
       "dev": true,
+      "requires": {
+        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+      },
       "dependencies": {
         "lodash.keys": {
           "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._isnative": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+            "lodash._shimkeys": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+            "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+          }
         }
       }
     },
     "lodash.words": {
       "version": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.2.0.tgz",
       "integrity": "sha1-TiqGSbwIdFsXxpWxo86P7llmI7M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._root": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
+      }
     },
     "longest": {
       "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -4666,12 +7162,19 @@
     },
     "loose-envify": {
       "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-      "integrity": "sha1-ayYkjEL21PpLDYVC947fzeNWQqg="
+      "integrity": "sha1-ayYkjEL21PpLDYVC947fzeNWQqg=",
+      "requires": {
+        "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
+      }
     },
     "loud-rejection": {
       "version": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+      }
     },
     "lru-cache": {
       "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
@@ -4705,12 +7208,28 @@
     "material-ui": {
       "version": "https://registry.npmjs.org/material-ui/-/material-ui-0.16.6.tgz",
       "integrity": "sha1-aDoDjCWm1343A6U6RAHzr0S8HbE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "inline-style-prefixer": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz",
+        "keycode": "https://registry.npmjs.org/keycode/-/keycode-2.1.8.tgz",
+        "lodash.merge": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+        "lodash.throttle": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+        "react-addons-create-fragment": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-15.4.1.tgz",
+        "react-addons-transition-group": "https://registry.npmjs.org/react-addons-transition-group/-/react-addons-transition-group-15.4.1.tgz",
+        "react-event-listener": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.4.0.tgz",
+        "recompose": "https://registry.npmjs.org/recompose/-/recompose-0.21.2.tgz",
+        "simple-assign": "https://registry.npmjs.org/simple-assign/-/simple-assign-0.1.0.tgz",
+        "warning": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz"
+      }
     },
     "math-expression-evaluator": {
       "version": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.14.tgz",
       "integrity": "sha1-OVEXce2WAkBfupr//xfrTSo4Q6s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash.indexof": "https://registry.npmjs.org/lodash.indexof/-/lodash.indexof-4.0.5.tgz"
+      }
     },
     "media-typer": {
       "version": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -4720,6 +7239,10 @@
       "version": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
+      "requires": {
+        "errno": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4729,7 +7252,16 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     },
@@ -4737,6 +7269,18 @@
       "version": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
+      "requires": {
+        "camelcase-keys": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+        "loud-rejection": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+        "map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+        "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+        "redent": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+        "trim-newlines": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+      },
       "dependencies": {
         "minimist": {
           "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -4753,6 +7297,9 @@
       "version": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4762,7 +7309,16 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     },
@@ -4770,11 +7326,20 @@
       "version": "https://registry.npmjs.org/method-override/-/method-override-2.3.7.tgz",
       "integrity": "sha1-jh1HrEgPsM2Hdwg/EciWkBFmsuU=",
       "dev": true,
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+        "methods": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+        "vary": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
+      },
       "dependencies": {
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+          }
         },
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
@@ -4790,7 +7355,22 @@
     "micromatch": {
       "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+        "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+        "braces": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+        "expand-brackets": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+        "extglob": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+        "filename-regex": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+        "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
+        "object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+        "parse-glob": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+        "regex-cache": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
+      }
     },
     "mime": {
       "version": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
@@ -4802,22 +7382,48 @@
     },
     "mime-types": {
       "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
-      "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog="
+      "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
+      "requires": {
+        "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
+      }
     },
     "min-document": {
       "version": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "dom-walk": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz"
+      }
     },
     "mini-lr": {
       "version": "https://registry.npmjs.org/mini-lr/-/mini-lr-0.1.9.tgz",
       "integrity": "sha1-AhmdJzR5U9H9HW297UJh8Yey0PY=",
       "dev": true,
+      "requires": {
+        "body-parser": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "faye-websocket": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz",
+        "livereload-js": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
+        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-2.2.5.tgz"
+      },
       "dependencies": {
         "body-parser": {
           "version": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
           "integrity": "sha1-EBXLH+LEQ4WCWVgdtTMy+NDPUPk=",
           "dev": true,
+          "requires": {
+            "bytes": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
+            "content-type": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+            "depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+            "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+            "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+            "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "qs": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+            "raw-body": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+            "type-is": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz"
+          },
           "dependencies": {
             "qs": {
               "version": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
@@ -4834,12 +7440,19 @@
         "faye-websocket": {
           "version": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz",
           "integrity": "sha1-zEB0x/Sk39A69U3WXDVLE1EyzhE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "websocket-driver": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz"
+          }
         },
         "http-errors": {
           "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
           "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+          }
         },
         "iconv-lite": {
           "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
@@ -4856,17 +7469,28 @@
     "minimatch": {
       "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+      }
     },
     "minimist": {
       "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
+    "mixpanel-browser": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.22.0.tgz",
+      "integrity": "sha512-K4MURmMuAwOakzfiVIVYQ8+j4viT+GzozKzQ9vlw1vJ0YhhutCH0keowrdbmRiR7iEN8JLXaZOwkkebzqL58mg=="
+    },
     "mkdirp": {
       "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+      }
     },
     "mock-promises": {
       "version": "https://registry.npmjs.org/mock-promises/-/mock-promises-0.8.1.tgz",
@@ -4876,7 +7500,10 @@
     "modify-babel-preset": {
       "version": "https://registry.npmjs.org/modify-babel-preset/-/modify-babel-preset-1.2.0.tgz",
       "integrity": "sha1-0bfIwkiW4Z28SEc0chPmtxRNG8c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "require-relative": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz"
+      }
     },
     "modify-filename": {
       "version": "https://registry.npmjs.org/modify-filename/-/modify-filename-1.1.0.tgz",
@@ -4892,6 +7519,13 @@
       "version": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
       "integrity": "sha1-X9gYOYxoGcuiinzWZk8pL+HAu/I=",
       "dev": true,
+      "requires": {
+        "basic-auth": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "depd": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
+        "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+        "on-headers": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
+      },
       "dependencies": {
         "depd": {
           "version": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
@@ -4903,7 +7537,10 @@
     "motion-ui": {
       "version": "https://registry.npmjs.org/motion-ui/-/motion-ui-1.2.2.tgz",
       "integrity": "sha1-7hO9xJjJ1pHw0pBxFK/YsNenay8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jquery": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz"
+      }
     },
     "ms": {
       "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -4917,17 +7554,30 @@
     "multimatch": {
       "version": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-differ": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+        "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+      }
     },
     "multiparty": {
       "version": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
       "integrity": "sha1-Nd5oBNwZZD5SSfPT473GyM4wHT8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+        "stream-counter": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
+      }
     },
     "multipipe": {
       "version": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
       "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
+      }
     },
     "mute-stream": {
       "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
@@ -4955,12 +7605,32 @@
     },
     "node-fetch": {
       "version": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
-      "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ="
+      "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
+      "requires": {
+        "encoding": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+        "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+      }
     },
     "node-gyp": {
       "version": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz",
       "integrity": "sha1-3aVYOTs+y74kyea4cDxxGUxj+jY=",
       "dev": true,
+      "requires": {
+        "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+        "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
+        "osenv": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+        "path-array": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+        "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.2.12.tgz"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -4970,7 +7640,13 @@
         "npmlog": {
           "version": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
           "integrity": "sha1-LUb6h0M3r5SYovErtD2NC+SjaHM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "are-we-there-yet": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+            "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+            "gauge": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
+            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+          }
         }
       }
     },
@@ -4978,6 +7654,31 @@
       "version": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz",
       "integrity": "sha1-PicsCBnjCJNeJmdECNevDhSRuDs=",
       "dev": true,
+      "requires": {
+        "assert": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+        "browserify-zlib": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+        "buffer": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+        "console-browserify": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+        "constants-browserify": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+        "crypto-browserify": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz",
+        "domain-browser": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+        "events": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+        "https-browserify": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+        "os-browserify": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
+        "path-browserify": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+        "process": "https://registry.npmjs.org/process/-/process-0.11.9.tgz",
+        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+        "querystring-es3": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+        "stream-browserify": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+        "stream-http": "https://registry.npmjs.org/stream-http/-/stream-http-2.5.0.tgz",
+        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+        "timers-browserify": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
+        "tty-browserify": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+        "url": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+        "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+        "vm-browserify": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4992,7 +7693,16 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     },
@@ -5000,16 +7710,42 @@
       "version": "https://registry.npmjs.org/node-sass/-/node-sass-3.13.1.tgz",
       "integrity": "sha1-ckD7v/I5YwS0IjUn7TAgWJwAT8I=",
       "dev": true,
+      "requires": {
+        "async-foreach": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+        "gaze": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "in-publish": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+        "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+        "lodash.clonedeep": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "nan": "https://registry.npmjs.org/nan/-/nan-2.5.0.tgz",
+        "node-gyp": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz",
+        "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+        "sass-graph": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.1.2.tgz"
+      },
       "dependencies": {
         "gaze": {
           "version": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
           "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "globule": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz"
+          }
         },
         "globule": {
           "version": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
           "integrity": "sha1-xJNS5NwYPYWJPuglOF65lLtt9F8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+          }
         },
         "lodash": {
           "version": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
@@ -5026,12 +7762,21 @@
     "nopt": {
       "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+      }
     },
     "normalize-package-data": {
       "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
       "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+        "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+        "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+      }
     },
     "normalize-path": {
       "version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
@@ -5046,12 +7791,102 @@
     "normalize-url": {
       "version": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.8.0.tgz",
       "integrity": "sha1-qVULB5qjUjyF143yTu8ZWfzjWas=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+        "prepend-http": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+        "query-string": "https://registry.npmjs.org/query-string/-/query-string-4.2.3.tgz",
+        "sort-keys": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz"
+      }
     },
     "npm": {
       "version": "https://registry.npmjs.org/npm/-/npm-3.10.10.tgz",
       "integrity": "sha1-Wx1XfkyIadbIYDvInpzRY3MD5G4=",
       "dev": true,
+      "requires": {
+        "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+        "ansicolors": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+        "ansistyles": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+        "aproba": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
+        "archy": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+        "asap": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+        "chownr": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+        "cmd-shim": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
+        "columnify": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+        "config-chain": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+        "debuglog": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+        "dezalgo": "1.0.3",
+        "editor": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+        "fs-vacuum": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.9.tgz",
+        "fs-write-stream-atomic": "1.0.8",
+        "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+        "fstream-npm": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.0.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+        "has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+        "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+        "iferr": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+        "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+        "init-package-json": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.4.tgz",
+        "lockfile": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.2.tgz",
+        "lodash._baseindexof": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+        "lodash._baseuniq": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+        "lodash._bindcallback": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+        "lodash._cacheindexof": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+        "lodash._createcache": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+        "lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+        "lodash.clonedeep": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+        "lodash.restparam": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+        "lodash.union": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+        "lodash.uniq": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+        "lodash.without": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "node-gyp": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz",
+        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+        "normalize-git-url": "3.0.2",
+        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+        "npm-cache-filename": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+        "npm-install-checks": "3.0.0",
+        "npm-package-arg": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.2.0.tgz",
+        "npm-registry-client": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.2.1.tgz",
+        "npm-user-validate": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.5.tgz",
+        "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.0.tgz",
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "opener": "https://registry.npmjs.org/opener/-/opener-1.4.2.tgz",
+        "osenv": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+        "read": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+        "read-cmd-shim": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
+        "read-installed": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+        "read-package-json": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.4.tgz",
+        "read-package-tree": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.5.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+        "readdir-scoped-modules": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
+        "realize-package-specifier": "3.0.3",
+        "request": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
+        "retry": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+        "sha": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+        "slide": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+        "sorted-object": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+        "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+        "text-table": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+        "uid-number": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+        "umask": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+        "unique-filename": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+        "unpipe": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+        "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+        "validate-npm-package-name": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+        "write-file-atomic": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.2.0.tgz"
+      },
       "dependencies": {
         "abbrev": {
           "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -5096,22 +7931,36 @@
         "cmd-shim": {
           "version": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
           "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+          }
         },
         "columnify": {
           "version": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
           "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
           "dev": true,
+          "requires": {
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "wcwidth": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz"
+          },
           "dependencies": {
             "wcwidth": {
               "version": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz",
               "integrity": "sha1-AtBZ/3qPx0Hg9rXaHmmytA2uym8=",
               "dev": true,
+              "requires": {
+                "defaults": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz"
+              },
               "dependencies": {
                 "defaults": {
                   "version": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
                   "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
                   "dev": true,
+                  "requires": {
+                    "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                  },
                   "dependencies": {
                     "clone": {
                       "version": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
@@ -5128,6 +7977,10 @@
           "version": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
           "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
           "dev": true,
+          "requires": {
+            "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+            "proto-list": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+          },
           "dependencies": {
             "proto-list": {
               "version": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -5154,7 +8007,12 @@
         "fs-vacuum": {
           "version": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.9.tgz",
           "integrity": "sha1-T5AZOrjqAokJlbzU6ARlml02ay0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+            "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
+          }
         },
         "fs-write-stream-atomic": {
           "version": "1.0.8",
@@ -5164,27 +8022,49 @@
         "fstream": {
           "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
           "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
+          }
         },
         "fstream-npm": {
           "version": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.0.tgz",
           "integrity": "sha1-0sPIkQE0aYLWTlcJHDhIe9qRb84=",
           "dev": true,
+          "requires": {
+            "fstream-ignore": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+          },
           "dependencies": {
             "fstream-ignore": {
               "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
               "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
               "dev": true,
+              "requires": {
+                "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+              },
               "dependencies": {
                 "minimatch": {
                   "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                   "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                   "dev": true,
+                  "requires": {
+                    "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+                  },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                       "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                       "dev": true,
+                      "requires": {
+                        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                      },
                       "dependencies": {
                         "balanced-match": {
                           "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
@@ -5208,6 +8088,14 @@
           "version": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
           "integrity": "sha1-Nq3YVtdG0NmeTMJ5e7oa4sZycv0=",
           "dev": true,
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          },
           "dependencies": {
             "fs.realpath": {
               "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5218,11 +8106,18 @@
               "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
               "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
               "dev": true,
+              "requires": {
+                "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                   "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                   "dev": true,
+                  "requires": {
+                    "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                    "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
@@ -5273,7 +8168,11 @@
         "inflight": {
           "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
           "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+          }
         },
         "inherits": {
           "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -5289,21 +8188,45 @@
           "version": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.4.tgz",
           "integrity": "sha1-tAU9C0Dwz4QqQZZpN8s9wPU06FY=",
           "dev": true,
+          "requires": {
+            "glob": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+            "npm-package-arg": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.2.0.tgz",
+            "promzard": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+            "read": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+            "read-package-json": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.4.tgz",
+            "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+            "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+            "validate-npm-package-name": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz"
+          },
           "dependencies": {
             "glob": {
               "version": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
               "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
               "dev": true,
+              "requires": {
+                "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                "path-is-absolute": "1.0.0"
+              },
               "dependencies": {
                 "minimatch": {
                   "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                   "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                   "dev": true,
+                  "requires": {
+                    "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+                  },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                       "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                       "dev": true,
+                      "requires": {
+                        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                        "concat-map": "0.0.1"
+                      },
                       "dependencies": {
                         "balanced-match": {
                           "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
@@ -5331,7 +8254,10 @@
             "promzard": {
               "version": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
               "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "read": "https://registry.npmjs.org/read/-/read-1.0.7.tgz"
+              }
             }
           }
         },
@@ -5349,6 +8275,10 @@
           "version": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
           "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
           "dev": true,
+          "requires": {
+            "lodash._createset": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+            "lodash._root": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
+          },
           "dependencies": {
             "lodash._createset": {
               "version": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
@@ -5375,7 +8305,10 @@
         "lodash._createcache": {
           "version": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
           "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+          }
         },
         "lodash._getnative": {
           "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
@@ -5411,6 +8344,9 @@
           "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "requires": {
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+          },
           "dependencies": {
             "minimist": {
               "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
@@ -5423,16 +8359,39 @@
           "version": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz",
           "integrity": "sha1-3aVYOTs+y74kyea4cDxxGUxj+jY=",
           "dev": true,
+          "requires": {
+            "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+            "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
+            "osenv": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+            "path-array": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
+            "request": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
+            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+            "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+            "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+            "which": "https://registry.npmjs.org/which/-/which-1.2.11.tgz"
+          },
           "dependencies": {
             "minimatch": {
               "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
               "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
               "dev": true,
+              "requires": {
+                "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                   "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                   "dev": true,
+                  "requires": {
+                    "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                    "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
@@ -5452,11 +8411,21 @@
               "version": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
               "integrity": "sha1-LUb6h0M3r5SYovErtD2NC+SjaHM=",
               "dev": true,
+              "requires": {
+                "are-we-there-yet": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+                "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                "gauge": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
+                "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+              },
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
                   "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
                   "dev": true,
+                  "requires": {
+                    "delegates": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                    "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
+                  },
                   "dependencies": {
                     "delegates": {
                       "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -5474,6 +8443,17 @@
                   "version": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
                   "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY=",
                   "dev": true,
+                  "requires": {
+                    "aproba": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
+                    "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                    "has-color": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                    "has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+                    "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+                    "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
+                    "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "wide-align": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
+                  },
                   "dependencies": {
                     "has-color": {
                       "version": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
@@ -5494,11 +8474,19 @@
                       "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "dev": true,
+                      "requires": {
+                        "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                        "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+                      },
                       "dependencies": {
                         "code-point-at": {
                           "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                           "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
                           "dev": true,
+                          "requires": {
+                            "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                          },
                           "dependencies": {
                             "number-is-nan": {
                               "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
@@ -5511,6 +8499,9 @@
                           "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                           "dev": true,
+                          "requires": {
+                            "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                          },
                           "dependencies": {
                             "number-is-nan": {
                               "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
@@ -5524,7 +8515,10 @@
                     "wide-align": {
                       "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
                       "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+                      }
                     }
                   }
                 },
@@ -5539,16 +8533,26 @@
               "version": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
               "integrity": "sha1-fi8PNfB6IBUSK4aLfqwOssT+wnE=",
               "dev": true,
+              "requires": {
+                "array-index": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz"
+              },
               "dependencies": {
                 "array-index": {
                   "version": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
                   "integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=",
                   "dev": true,
+                  "requires": {
+                    "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                    "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
+                  },
                   "dependencies": {
                     "debug": {
                       "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
                       "dev": true,
+                      "requires": {
+                        "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                      },
                       "dependencies": {
                         "ms": {
                           "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -5561,21 +8565,37 @@
                       "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
                       "integrity": "sha1-lEgcZV56fK2C66gy2X1UM0ltf/o=",
                       "dev": true,
+                      "requires": {
+                        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
+                      },
                       "dependencies": {
                         "d": {
                           "version": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
                           "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
-                          "dev": true
+                          "dev": true,
+                          "requires": {
+                            "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
+                          }
                         },
                         "es5-ext": {
                           "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
                           "integrity": "sha1-qoRkHU23a2Krul5F/YBey6sUAEc=",
                           "dev": true,
+                          "requires": {
+                            "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+                            "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
+                          },
                           "dependencies": {
                             "es6-iterator": {
                               "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
                               "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
-                              "dev": true
+                              "dev": true,
+                              "requires": {
+                                "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                                "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
+                                "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
+                              }
                             }
                           }
                         }
@@ -5590,7 +8610,10 @@
         "nopt": {
           "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+          }
         },
         "normalize-git-url": {
           "version": "3.0.2",
@@ -5601,11 +8624,20 @@
           "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
           "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
           "dev": true,
+          "requires": {
+            "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+            "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+            "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+          },
           "dependencies": {
             "is-builtin-module": {
               "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
               "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
               "dev": true,
+              "requires": {
+                "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+              },
               "dependencies": {
                 "builtin-modules": {
                   "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -5629,22 +8661,51 @@
         "npm-package-arg": {
           "version": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.2.0.tgz",
           "integrity": "sha1-gJvGHKv1S9X/lPYWXIm6juiMEVw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+            "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+          }
         },
         "npm-registry-client": {
           "version": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.2.1.tgz",
           "integrity": "sha1-x5ImawiMwxP4Ul5+NSSGJscj23U=",
           "dev": true,
+          "requires": {
+            "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+            "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+            "npm-package-arg": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.2.0.tgz",
+            "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "request": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
+            "retry": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
+            "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+            "slide": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+          },
           "dependencies": {
             "concat-stream": {
               "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
               "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
               "dev": true,
+              "requires": {
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+              },
               "dependencies": {
                 "readable-stream": {
                   "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                   "dev": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -5689,12 +8750,22 @@
               "integrity": "sha1-LUb6h0M3r5SYovErtD2NC+SjaHM=",
               "dev": true,
               "optional": true,
+              "requires": {
+                "are-we-there-yet": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+                "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                "gauge": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
+                "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+              },
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
                   "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
                   "dev": true,
                   "optional": true,
+                  "requires": {
+                    "delegates": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                    "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
+                  },
                   "dependencies": {
                     "delegates": {
                       "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -5714,6 +8785,17 @@
                   "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY=",
                   "dev": true,
                   "optional": true,
+                  "requires": {
+                    "aproba": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
+                    "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                    "has-color": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                    "has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+                    "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+                    "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
+                    "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "wide-align": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
+                  },
                   "dependencies": {
                     "has-color": {
                       "version": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
@@ -5737,11 +8819,19 @@
                       "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "dev": true,
+                      "requires": {
+                        "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                        "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+                      },
                       "dependencies": {
                         "code-point-at": {
                           "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                           "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
                           "dev": true,
+                          "requires": {
+                            "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                          },
                           "dependencies": {
                             "number-is-nan": {
                               "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
@@ -5754,6 +8844,9 @@
                           "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                           "dev": true,
+                          "requires": {
+                            "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                          },
                           "dependencies": {
                             "number-is-nan": {
                               "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
@@ -5768,7 +8861,10 @@
                       "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
                       "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
                       "dev": true,
-                      "optional": true
+                      "optional": true,
+                      "requires": {
+                        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+                      }
                     }
                   }
                 },
@@ -5796,11 +8892,21 @@
           "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.0.tgz",
           "integrity": "sha1-4JRQOWHHDBd063ZpIIDo1Xip+I8=",
           "dev": true,
+          "requires": {
+            "are-we-there-yet": "http://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+            "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+            "gauge": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
+            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+          },
           "dependencies": {
             "are-we-there-yet": {
               "version": "http://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
               "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
               "dev": true,
+              "requires": {
+                "delegates": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
+              },
               "dependencies": {
                 "delegates": {
                   "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -5818,6 +8924,17 @@
               "version": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
               "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY=",
               "dev": true,
+              "requires": {
+                "aproba": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
+                "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                "has-color": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                "has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+                "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
+                "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                "wide-align": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
+              },
               "dependencies": {
                 "has-color": {
                   "version": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
@@ -5838,11 +8955,19 @@
                   "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
+                  "requires": {
+                    "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                    "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+                  },
                   "dependencies": {
                     "code-point-at": {
                       "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                       "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
                       "dev": true,
+                      "requires": {
+                        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                      },
                       "dependencies": {
                         "number-is-nan": {
                           "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
@@ -5855,6 +8980,9 @@
                       "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                       "dev": true,
+                      "requires": {
+                        "number-is-nan": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                      },
                       "dependencies": {
                         "number-is-nan": {
                           "version": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
@@ -5868,7 +8996,10 @@
                 "wide-align": {
                   "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
                   "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+                  }
                 }
               }
             },
@@ -5882,7 +9013,10 @@
         "once": {
           "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+          }
         },
         "opener": {
           "version": "https://registry.npmjs.org/opener/-/opener-1.4.2.tgz",
@@ -5893,6 +9027,10 @@
           "version": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
           "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
           "dev": true,
+          "requires": {
+            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+            "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+          },
           "dependencies": {
             "os-homedir": {
               "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
@@ -5915,6 +9053,9 @@
           "version": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
           "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
           "dev": true,
+          "requires": {
+            "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+          },
           "dependencies": {
             "mute-stream": {
               "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
@@ -5926,12 +9067,24 @@
         "read-cmd-shim": {
           "version": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
           "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
+          }
         },
         "read-installed": {
           "version": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
           "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
           "dev": true,
+          "requires": {
+            "debuglog": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+            "read-package-json": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.4.tgz",
+            "readdir-scoped-modules": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
+            "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+            "slide": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+            "util-extend": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz"
+          },
           "dependencies": {
             "util-extend": {
               "version": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
@@ -5944,21 +9097,41 @@
           "version": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.4.tgz",
           "integrity": "sha1-Ye0bIlbqQ42ACIlQkL6EuOeZyFM=",
           "dev": true,
+          "requires": {
+            "glob": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+            "json-parse-helpfulerror": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+            "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
+          },
           "dependencies": {
             "glob": {
               "version": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
               "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
               "dev": true,
+              "requires": {
+                "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                "path-is-absolute": "1.0.0"
+              },
               "dependencies": {
                 "minimatch": {
                   "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                   "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                   "dev": true,
+                  "requires": {
+                    "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+                  },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                       "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                       "dev": true,
+                      "requires": {
+                        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                        "concat-map": "0.0.1"
+                      },
                       "dependencies": {
                         "balanced-match": {
                           "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
@@ -5987,6 +9160,9 @@
               "version": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
               "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
               "dev": true,
+              "requires": {
+                "jju": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz"
+              },
               "dependencies": {
                 "jju": {
                   "version": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
@@ -6000,12 +9176,28 @@
         "read-package-tree": {
           "version": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.5.tgz",
           "integrity": "sha1-rOfmOBx2hPlwqqmPx8XStmat2rY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "debuglog": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+            "dezalgo": "1.0.3",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "read-package-json": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.4.tgz",
+            "readdir-scoped-modules": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz"
+          }
         },
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
           "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
           "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "1.0.2",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          },
           "dependencies": {
             "buffer-shims": {
               "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
@@ -6044,7 +9236,13 @@
         "readdir-scoped-modules": {
           "version": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
           "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "debuglog": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+            "dezalgo": "1.0.3",
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+          }
         },
         "realize-package-specifier": {
           "version": "3.0.3",
@@ -6055,6 +9253,29 @@
           "version": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
           "integrity": "sha1-0rgmiihtoT6qXQGt9dGMyQ9lfZM=",
           "dev": true,
+          "requires": {
+            "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+            "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
+            "bl": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+            "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+            "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+            "extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+            "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
+            "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+            "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+            "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+            "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+            "node-uuid": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+            "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "qs": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+            "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+            "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+          },
           "dependencies": {
             "aws-sign2": {
               "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
@@ -6070,11 +9291,22 @@
               "version": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
               "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
               "dev": true,
+              "requires": {
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+              },
               "dependencies": {
                 "readable-stream": {
                   "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                   "dev": true,
+                  "requires": {
+                    "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                    "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                    "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                  },
                   "dependencies": {
                     "core-util-is": {
                       "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -6114,6 +9346,9 @@
               "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
               "dev": true,
+              "requires": {
+                "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+              },
               "dependencies": {
                 "delayed-stream": {
                   "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -6136,6 +9371,11 @@
               "version": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
               "integrity": "sha1-bwrrrcxdoWwT4ezBETfYX5uIOyU=",
               "dev": true,
+              "requires": {
+                "asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
+              },
               "dependencies": {
                 "asynckit": {
                   "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -6148,11 +9388,24 @@
               "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
               "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
               "dev": true,
+              "requires": {
+                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+              },
               "dependencies": {
                 "chalk": {
                   "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                   "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                   "dev": true,
+                  "requires": {
+                    "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                    "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                  },
                   "dependencies": {
                     "ansi-styles": {
                       "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -6167,7 +9420,10 @@
                     "has-ansi": {
                       "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                      }
                     },
                     "supports-color": {
                       "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -6180,6 +9436,9 @@
                   "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                   "dev": true,
+                  "requires": {
+                    "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                  },
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
@@ -6192,6 +9451,12 @@
                   "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
                   "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
                   "dev": true,
+                  "requires": {
+                    "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                    "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                    "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
+                    "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                  },
                   "dependencies": {
                     "generate-function": {
                       "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
@@ -6202,6 +9467,9 @@
                       "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
                       "dev": true,
+                      "requires": {
+                        "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                      },
                       "dependencies": {
                         "is-property": {
                           "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -6226,6 +9494,9 @@
                   "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                   "dev": true,
+                  "requires": {
+                    "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                  },
                   "dependencies": {
                     "pinkie": {
                       "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
@@ -6240,16 +9511,28 @@
               "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
               "dev": true,
+              "requires": {
+                "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+              },
               "dependencies": {
                 "boom": {
                   "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                   "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                  }
                 },
                 "cryptiles": {
                   "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                   "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                  }
                 },
                 "hoek": {
                   "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
@@ -6259,7 +9542,10 @@
                 "sntp": {
                   "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                   "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                  }
                 }
               }
             },
@@ -6267,6 +9553,11 @@
               "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
               "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
               "dev": true,
+              "requires": {
+                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+                "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz"
+              },
               "dependencies": {
                 "assert-plus": {
                   "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
@@ -6277,6 +9568,11 @@
                   "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
                   "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
                   "dev": true,
+                  "requires": {
+                    "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                    "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                    "verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                  },
                   "dependencies": {
                     "extsprintf": {
                       "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
@@ -6291,7 +9587,10 @@
                     "verror": {
                       "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
                       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                      }
                     }
                   }
                 },
@@ -6299,6 +9598,17 @@
                   "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
                   "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
                   "dev": true,
+                  "requires": {
+                    "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                    "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                    "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+                    "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                    "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+                    "jodid25519": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                    "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                    "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+                  },
                   "dependencies": {
                     "asn1": {
                       "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -6314,29 +9624,44 @@
                       "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
                       "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
                       "dev": true,
-                      "optional": true
+                      "optional": true,
+                      "requires": {
+                        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+                      }
                     },
                     "dashdash": {
                       "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
                       "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                      }
                     },
                     "ecc-jsbn": {
                       "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                       "dev": true,
-                      "optional": true
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                      }
                     },
                     "getpass": {
                       "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
                       "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                      }
                     },
                     "jodid25519": {
                       "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
                       "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
                       "dev": true,
-                      "optional": true
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                      }
                     },
                     "jsbn": {
                       "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
@@ -6373,6 +9698,9 @@
               "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
               "integrity": "sha1-FSuiVndwIN1GY/VMLnvCY4HnFyk=",
               "dev": true,
+              "requires": {
+                "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+              },
               "dependencies": {
                 "mime-db": {
                   "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
@@ -6421,7 +9749,10 @@
         "rimraf": {
           "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
           "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz"
+          }
         },
         "semver": {
           "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -6431,7 +9762,11 @@
         "sha": {
           "version": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
           "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
+          }
         },
         "slide": {
           "version": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
@@ -6446,17 +9781,28 @@
         "strip-ansi": {
           "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+          }
         },
         "tar": {
           "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
+          "requires": {
+            "block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
+            "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+          },
           "dependencies": {
             "block-stream": {
               "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
               "integrity": "sha1-Boj0baK7+c/wxPaCJaDLlcvopGs=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+              }
             }
           }
         },
@@ -6479,11 +9825,18 @@
           "version": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
           "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
           "dev": true,
+          "requires": {
+            "unique-slug": "2.0.0"
+          },
           "dependencies": {
             "unique-slug": {
               "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
               "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+              }
             }
           }
         },
@@ -6496,11 +9849,18 @@
           "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
           "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
           "dev": true,
+          "requires": {
+            "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+            "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
+          },
           "dependencies": {
             "spdx-correct": {
               "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
               "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
               "dev": true,
+              "requires": {
+                "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+              },
               "dependencies": {
                 "spdx-license-ids": {
                   "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
@@ -6513,6 +9873,10 @@
               "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
               "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
               "dev": true,
+              "requires": {
+                "spdx-exceptions": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+                "spdx-license-ids": "1.2.0"
+              },
               "dependencies": {
                 "spdx-exceptions": {
                   "version": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
@@ -6533,6 +9897,9 @@
           "version": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz",
           "integrity": "sha1-9laVsi9zJEQgGaPH+jmm5/0pkIU=",
           "dev": true,
+          "requires": {
+            "builtins": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
+          },
           "dependencies": {
             "builtins": {
               "version": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
@@ -6545,6 +9912,9 @@
           "version": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
           "integrity": "sha1-yLLu6muMFln6fB3U/aq+lTPcXos=",
           "dev": true,
+          "requires": {
+            "isexe": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+          },
           "dependencies": {
             "isexe": {
               "version": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
@@ -6561,24 +9931,49 @@
         "write-file-atomic": {
           "version": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.2.0.tgz",
           "integrity": "sha1-FMZtTkyzygVlwozzt6bz5NWTj6s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+            "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "slide": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+          }
         }
       }
     },
     "npm-install-package": {
       "version": "https://registry.npmjs.org/npm-install-package/-/npm-install-package-1.1.0.tgz",
       "integrity": "sha1-+fwfhMLTH2EFYx4LX18oDRFR2X4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "noop2": "https://registry.npmjs.org/noop2/-/noop2-2.0.0.tgz"
+      }
     },
     "npmlog": {
       "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
       "integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518=",
       "dev": true,
+      "requires": {
+        "are-we-there-yet": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+        "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+        "gauge": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz",
+        "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+      },
       "dependencies": {
         "gauge": {
           "version": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz",
           "integrity": "sha1-Fc7MMbAtBTRaXWsOFxzbOtIwd3Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "aproba": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
+            "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+            "has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+            "wide-align": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
+          }
         },
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
@@ -6614,11 +10009,18 @@
     "object.omit": {
       "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-own": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
+        "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+      }
     },
     "on-finished": {
       "version": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc="
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+      }
     },
     "on-headers": {
       "version": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
@@ -6628,7 +10030,10 @@
     "once": {
       "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+      }
     },
     "onetime": {
       "version": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
@@ -6639,6 +10044,10 @@
       "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
+      "requires": {
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -6650,12 +10059,25 @@
     "optionator": {
       "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+        "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+      }
     },
     "orchestrator": {
       "version": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
       "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "end-of-stream": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+        "sequencify": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
+        "stream-consume": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
+      }
     },
     "ordered-read-streams": {
       "version": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
@@ -6675,7 +10097,10 @@
     "os-locale": {
       "version": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lcid": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+      }
     },
     "os-shim": {
       "version": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
@@ -6690,17 +10115,28 @@
     "osenv": {
       "version": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+        "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+      }
     },
     "p-flux": {
       "version": "https://registry.npmjs.org/p-flux/-/p-flux-1.1.0.tgz",
       "integrity": "sha1-2AeBjLfDSQIQzlI5+lk+e/L4P7s=",
       "dev": true,
+      "requires": {
+        "pui-cursor": "https://registry.npmjs.org/pui-cursor/-/pui-cursor-3.0.4.tgz",
+        "warning": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz"
+      },
       "dependencies": {
         "warning": {
           "version": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
           "integrity": "sha1-ISINnGOvx3qMkhEeARr3Bc4MaQE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz"
+          }
         }
       }
     },
@@ -6712,17 +10148,31 @@
     "parse-filepath": {
       "version": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
       "integrity": "sha1-FZ1hVdQ5BNFsEO9piRHaHpGWm3M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-absolute": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+        "map-cache": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+        "path-root": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz"
+      }
     },
     "parse-glob": {
       "version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-base": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+        "is-dotfile": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+      }
     },
     "parse-json": {
       "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "error-ex": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
+      }
     },
     "parse-passwd": {
       "version": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -6736,7 +10186,10 @@
     "path-array": {
       "version": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
       "integrity": "sha1-fi8PNfB6IBUSK4aLfqwOssT+wnE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-index": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz"
+      }
     },
     "path-browserify": {
       "version": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
@@ -6751,7 +10204,10 @@
     "path-exists": {
       "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      }
     },
     "path-is-absolute": {
       "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -6766,7 +10222,10 @@
     "path-root": {
       "version": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-root-regex": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz"
+      }
     },
     "path-root-regex": {
       "version": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
@@ -6781,6 +10240,11 @@
       "version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -6796,7 +10260,10 @@
     },
     "pause-stream": {
       "version": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU="
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "requires": {
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      }
     },
     "pbkdf2-compat": {
       "version": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
@@ -6811,7 +10278,18 @@
     "phantomjs-prebuilt": {
       "version": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.14.tgz",
       "integrity": "sha1-1T0xH8+30dCN2yQBRVjxGIxRbaA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-promise": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
+        "extract-zip": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
+        "fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+        "hasha": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+        "kew": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+        "progress": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+        "request-progress": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.2.12.tgz"
+      }
     },
     "pify": {
       "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -6826,17 +10304,28 @@
     "pinkie-promise": {
       "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+      }
     },
     "pivotal-js-jasmine-matchers": {
       "version": "https://registry.npmjs.org/pivotal-js-jasmine-matchers/-/pivotal-js-jasmine-matchers-0.0.17.tgz",
       "integrity": "sha1-9CHGZYSMlAtjrBecbZnI9uV/JGw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jasmine-ajax": "https://registry.npmjs.org/jasmine-ajax/-/jasmine-ajax-3.3.1.tgz",
+        "jasmine_dom_matchers": "https://registry.npmjs.org/jasmine_dom_matchers/-/jasmine_dom_matchers-1.4.0.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-5.2.1.tgz"
+      }
     },
     "pkg-dir": {
       "version": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
+      }
     },
     "pluralize": {
       "version": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
@@ -6846,79 +10335,139 @@
     "portfinder": {
       "version": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.10.tgz",
       "integrity": "sha1-ek3p2YVTwxXabx4e0FE47rLRa7g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+      }
     },
     "postcss": {
       "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
       "integrity": "sha1-BXIMSd8jx5vaUf0B2usekiLpQ5A=",
       "dev": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+      },
       "dependencies": {
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
         }
       }
     },
     "postcss-calc": {
       "version": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "postcss-message-helpers": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+        "reduce-css-calc": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz"
+      }
     },
     "postcss-colormin": {
       "version": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.1.tgz",
       "integrity": "sha1-3FQhtq5vd572v9RzUrlKvlnQMWs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "colormin": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "postcss-convert-values": {
       "version": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.0.tgz",
       "integrity": "sha1-CMbQYTD+WKkaIf9Qgp4arWo6Gsw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "postcss-discard-comments": {
       "version": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz"
+      }
     },
     "postcss-discard-duplicates": {
       "version": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.2.tgz",
       "integrity": "sha1-Ar5SDpFXH/sQc4dmqYHVdwmJuzI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz"
+      }
     },
     "postcss-discard-empty": {
       "version": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz"
+      }
     },
     "postcss-discard-overridden": {
       "version": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz"
+      }
     },
     "postcss-discard-unused": {
       "version": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+      }
     },
     "postcss-filter-plugins": {
       "version": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
       "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "uniqid": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.0.tgz"
+      }
     },
     "postcss-merge-idents": {
       "version": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "postcss-merge-longhand": {
       "version": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz",
       "integrity": "sha1-/1m13sbVhs4s6hgxOPVcWHb6nNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz"
+      }
     },
     "postcss-merge-rules": {
       "version": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.11.tgz",
       "integrity": "sha1-xdfI3lBWpzd66g3/L9g/ksr7m4o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "vendors": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz"
+      }
     },
     "postcss-message-helpers": {
       "version": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
@@ -6928,42 +10477,80 @@
     "postcss-minify-font-values": {
       "version": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "postcss-minify-gradients": {
       "version": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "postcss-minify-params": {
       "version": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+        "uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+      }
     },
     "postcss-minify-selectors": {
       "version": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "postcss-selector-parser": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.2.tgz"
+      }
     },
     "postcss-modules-extract-imports": {
       "version": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.0.1.tgz",
       "integrity": "sha1-j7P++abdBCDT9tQ1PPH/c/Kyo0E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz"
+      }
     },
     "postcss-modules-local-by-default": {
       "version": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.1.1.tgz",
       "integrity": "sha1-KaEGc/o30ZJRJlyiujFQ2QQOtM4=",
       "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.6.0.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz"
+      },
       "dependencies": {
         "css-selector-tokenizer": {
           "version": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.6.0.tgz",
           "integrity": "sha1-ZEX1gseTDSQdzFAHpD1vy48HMVI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "cssesc": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+            "fastparse": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+            "regexpu-core": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz"
+          }
         },
         "regexpu-core": {
           "version": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "regenerate": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+            "regjsgen": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+            "regjsparser": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
+          }
         }
       }
     },
@@ -6971,68 +10558,127 @@
       "version": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.0.2.tgz",
       "integrity": "sha1-/5dzleXgYgLXNiKQuIsejNBJ3ik=",
       "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.6.0.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz"
+      },
       "dependencies": {
         "css-selector-tokenizer": {
           "version": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.6.0.tgz",
           "integrity": "sha1-ZEX1gseTDSQdzFAHpD1vy48HMVI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "cssesc": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+            "fastparse": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+            "regexpu-core": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz"
+          }
         },
         "regexpu-core": {
           "version": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "regenerate": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+            "regjsgen": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+            "regjsparser": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
+          }
         }
       }
     },
     "postcss-modules-values": {
       "version": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.2.2.tgz",
       "integrity": "sha1-8OfUdv4e2IxeTH+XUzo+dyrZTKE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "icss-replace-symbols": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.0.2.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz"
+      }
     },
     "postcss-normalize-charset": {
       "version": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz"
+      }
     },
     "postcss-normalize-url": {
       "version": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-absolute-url": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+        "normalize-url": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.8.0.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "postcss-ordered-values": {
       "version": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.2.tgz",
       "integrity": "sha1-votRF0H6strI5hSiMC6dECZ7B3E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "postcss-reduce-idents": {
       "version": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "postcss-reduce-initial": {
       "version": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz"
+      }
     },
     "postcss-reduce-transforms": {
       "version": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "postcss-selector-parser": {
       "version": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.2.tgz",
       "integrity": "sha1-PXD1rdoTDaUcfAwvwCP1axN0/gg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flatten": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+        "indexes-of": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+        "uniq": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+      }
     },
     "postcss-svgo": {
       "version": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-svg": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+        "svgo": "https://registry.npmjs.org/svgo/-/svgo-0.7.1.tgz"
+      }
     },
     "postcss-unique-selectors": {
       "version": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+      }
     },
     "postcss-value-parser": {
       "version": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
@@ -7042,7 +10688,12 @@
     "postcss-zindex": {
       "version": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.8.tgz",
+        "uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+      }
     },
     "prelude-ls": {
       "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -7082,7 +10733,13 @@
     "progeny": {
       "version": "https://registry.npmjs.org/progeny/-/progeny-0.7.0.tgz",
       "integrity": "sha1-SPkj11lB4Vc+H12NPbMdrjEsz0U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "async-each": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "fs-mode": "https://registry.npmjs.org/fs-mode/-/fs-mode-1.0.1.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+      }
     },
     "progress": {
       "version": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
@@ -7091,11 +10748,18 @@
     },
     "promise": {
       "version": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
-      "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8="
+      "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8=",
+      "requires": {
+        "asap": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
+      }
     },
     "proxy-addr": {
       "version": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
-      "integrity": "sha1-tMxfImENlTWCTBI675089zxAujc="
+      "integrity": "sha1-tMxfImENlTWCTBI675089zxAujc=",
+      "requires": {
+        "forwarded": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+        "ipaddr.js": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
+      }
     },
     "prr": {
       "version": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
@@ -7111,6 +10775,13 @@
       "version": "https://registry.npmjs.org/pui-cursor/-/pui-cursor-3.0.4.tgz",
       "integrity": "sha1-3SeA5xd+I3p+zJhVa1RBLCxG++k=",
       "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "immutability-helper": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.1.0.tgz",
+        "lodash.flow": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
+        "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+        "warning": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz"
+      },
       "dependencies": {
         "lodash.isobject": {
           "version": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
@@ -7120,7 +10791,10 @@
         "warning": {
           "version": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
           "integrity": "sha1-ISINnGOvx3qMkhEeARr3Bc4MaQE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz"
+          }
         }
       }
     },
@@ -7128,16 +10802,97 @@
       "version": "https://registry.npmjs.org/pui-react-tools/-/pui-react-tools-2.0.3.tgz",
       "integrity": "sha1-M0ZrwRxHd2W6RJB46it8syT7gVs=",
       "dev": true,
+      "requires": {
+        "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-6.21.0.tgz",
+        "babel-eslint": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz",
+        "babel-loader": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.2.10.tgz",
+        "babel-plugin-transform-object-assign": "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.8.0.tgz",
+        "babel-plugin-transform-react-display-name": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.8.0.tgz",
+        "babel-polyfill": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.20.0.tgz",
+        "babel-preset-es2015": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.18.0.tgz",
+        "babel-preset-es2015-loose": "https://registry.npmjs.org/babel-preset-es2015-loose/-/babel-preset-es2015-loose-7.0.0.tgz",
+        "babel-preset-react": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.16.0.tgz",
+        "babel-preset-stage-0": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.16.0.tgz",
+        "cors": "https://registry.npmjs.org/cors/-/cors-2.8.1.tgz",
+        "css-loader": "https://registry.npmjs.org/css-loader/-/css-loader-0.23.1.tgz",
+        "del": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+        "eslint-plugin-react": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.8.0.tgz",
+        "express": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
+        "extract-text-webpack-plugin": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-1.0.1.tgz",
+        "file-loader": "https://registry.npmjs.org/file-loader/-/file-loader-0.9.0.tgz",
+        "foreman": "https://registry.npmjs.org/foreman/-/foreman-1.4.1.tgz",
+        "from2": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+        "gulp": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+        "gulp-autoprefixer": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-3.1.1.tgz",
+        "gulp-babel": "https://registry.npmjs.org/gulp-babel/-/gulp-babel-6.1.2.tgz",
+        "gulp-clone": "https://registry.npmjs.org/gulp-clone/-/gulp-clone-1.0.0.tgz",
+        "gulp-cond": "https://registry.npmjs.org/gulp-cond/-/gulp-cond-1.0.0.tgz",
+        "gulp-cssnano": "https://registry.npmjs.org/gulp-cssnano/-/gulp-cssnano-2.1.2.tgz",
+        "gulp-env": "https://registry.npmjs.org/gulp-env/-/gulp-env-0.4.0.tgz",
+        "gulp-eslint": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-3.0.1.tgz",
+        "gulp-filter": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-4.0.0.tgz",
+        "gulp-gzip": "https://registry.npmjs.org/gulp-gzip/-/gulp-gzip-1.4.0.tgz",
+        "gulp-if": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+        "gulp-jasmine": "https://registry.npmjs.org/gulp-jasmine/-/gulp-jasmine-2.4.2.tgz",
+        "gulp-jasmine-browser": "https://registry.npmjs.org/gulp-jasmine-browser/-/gulp-jasmine-browser-1.7.1.tgz",
+        "gulp-livereload": "https://registry.npmjs.org/gulp-livereload/-/gulp-livereload-3.8.1.tgz",
+        "gulp-load-plugins": "https://registry.npmjs.org/gulp-load-plugins/-/gulp-load-plugins-1.4.0.tgz",
+        "gulp-plumber": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.1.0.tgz",
+        "gulp-process-env": "https://registry.npmjs.org/gulp-process-env/-/gulp-process-env-0.0.2.tgz",
+        "gulp-progeny": "https://registry.npmjs.org/gulp-progeny/-/gulp-progeny-0.3.2.tgz",
+        "gulp-rename": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
+        "gulp-rev": "https://registry.npmjs.org/gulp-rev/-/gulp-rev-7.1.2.tgz",
+        "gulp-rev-css-url": "https://registry.npmjs.org/gulp-rev-css-url/-/gulp-rev-css-url-0.1.0.tgz",
+        "gulp-sass": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-2.3.2.tgz",
+        "gulp-sourcemaps": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.9.1.tgz",
+        "gulp-tap": "https://registry.npmjs.org/gulp-tap/-/gulp-tap-0.1.3.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "gulp-wait": "https://registry.npmjs.org/gulp-wait/-/gulp-wait-0.0.2.tgz",
+        "gulp-watch": "https://registry.npmjs.org/gulp-watch/-/gulp-watch-4.3.11.tgz",
+        "invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+        "lazypipe": "https://registry.npmjs.org/lazypipe/-/lazypipe-1.0.1.tgz",
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
+        "lodash.camelcase": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+        "lodash.debounce": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+        "lsof": "https://registry.npmjs.org/lsof/-/lsof-0.1.0.tgz",
+        "merge-stream": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+        "multipipe": "https://registry.npmjs.org/multipipe/-/multipipe-0.3.1.tgz",
+        "npm": "https://registry.npmjs.org/npm/-/npm-3.10.10.tgz",
+        "portfinder": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.10.tgz",
+        "react": "https://registry.npmjs.org/react/-/react-15.4.1.tgz",
+        "react-addons-test-utils": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.4.1.tgz",
+        "react-dom": "https://registry.npmjs.org/react-dom/-/react-dom-15.4.1.tgz",
+        "react-hot-loader": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-3.0.0-beta.6.tgz",
+        "require-dir": "0.3.2",
+        "run-sequence": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.2.2.tgz",
+        "sass-loader": "https://registry.npmjs.org/sass-loader/-/sass-loader-4.1.1.tgz",
+        "style-loader": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "through2-spy": "https://registry.npmjs.org/through2-spy/-/through2-spy-2.0.0.tgz",
+        "url-join": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+        "url-loader": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.7.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+        "webpack-dev-middleware": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.9.0.tgz",
+        "webpack-hot-middleware": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.15.0.tgz",
+        "webpack-stream": "https://registry.npmjs.org/webpack-stream/-/webpack-stream-3.2.0.tgz"
+      },
       "dependencies": {
         "duplexer2": {
           "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          }
         },
         "gulp-process-env": {
           "version": "https://registry.npmjs.org/gulp-process-env/-/gulp-process-env-0.0.2.tgz",
           "integrity": "sha1-W9E6Q7tq1PqA8ghbELHr2JG6QKM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+          }
         },
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -7147,12 +10902,24 @@
         "multipipe": {
           "version": "https://registry.npmjs.org/multipipe/-/multipipe-0.3.1.tgz",
           "integrity": "sha1-kmJVJXYboE/qoJYFtjgrziyR8R8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
+          }
         },
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         },
         "url-join": {
           "version": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
@@ -7162,7 +10929,12 @@
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+          }
         }
       }
     },
@@ -7184,7 +10956,11 @@
     "query-string": {
       "version": "https://registry.npmjs.org/query-string/-/query-string-4.2.3.tgz",
       "integrity": "sha1-nycnPSB6JajuTHuMdNzUXVVtuCI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+        "strict-uri-encode": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
+      }
     },
     "querystring": {
       "version": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -7204,7 +10980,11 @@
     "randomatic": {
       "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
       "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz"
+      }
     },
     "range-parser": {
       "version": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -7214,6 +10994,11 @@
       "version": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
       "integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
       "dev": true,
+      "requires": {
+        "bytes": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+        "unpipe": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+      },
       "dependencies": {
         "bytes": {
           "version": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
@@ -7229,7 +11014,12 @@
     },
     "react": {
       "version": "https://registry.npmjs.org/react/-/react-15.4.1.tgz",
-      "integrity": "sha1-SY6RhgJnejmDzQ/SBt/nADiaDdY="
+      "integrity": "sha1-SY6RhgJnejmDzQ/SBt/nADiaDdY=",
+      "requires": {
+        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.8.tgz",
+        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+      }
     },
     "react-addons-create-fragment": {
       "version": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-15.4.1.tgz",
@@ -7253,7 +11043,11 @@
     },
     "react-autosize-textarea": {
       "version": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-0.3.4.tgz",
-      "integrity": "sha1-O2L7AfSFEMsYyJTa7+Sf+yvYUDk="
+      "integrity": "sha1-O2L7AfSFEMsYyJTa7+Sf+yvYUDk=",
+      "requires": {
+        "autosize": "https://registry.npmjs.org/autosize/-/autosize-3.0.20.tgz",
+        "tcomb-react": "https://registry.npmjs.org/tcomb-react/-/tcomb-react-0.9.3.tgz"
+      }
     },
     "react-deep-force-update": {
       "version": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-2.0.1.tgz",
@@ -7263,51 +11057,93 @@
     "react-dom": {
       "version": "https://registry.npmjs.org/react-dom/-/react-dom-15.4.1.tgz",
       "integrity": "sha1-1UyRMmGq7bF63CBBDQKdzBihNEo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.8.tgz",
+        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+      }
     },
     "react-event-listener": {
       "version": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.4.0.tgz",
       "integrity": "sha1-JsQKsY+fDg2NH+2cNGXnnAqZyaU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "react-addons-shallow-compare": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.4.1.tgz",
+        "warning": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz"
+      }
     },
     "react-google-login": {
       "version": "https://registry.npmjs.org/react-google-login/-/react-google-login-2.5.8.tgz",
       "integrity": "sha1-+In8JH89XHIMRepNjLBEsj6TAak=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/react": "https://registry.npmjs.org/@types/react/-/react-0.14.55.tgz"
+      }
     },
     "react-helmet": {
       "version": "https://registry.npmjs.org/react-helmet/-/react-helmet-3.3.0.tgz",
-      "integrity": "sha1-QZkz585addBKqz/v53Fp7tjlVkY="
+      "integrity": "sha1-QZkz585addBKqz/v53Fp7tjlVkY=",
+      "requires": {
+        "deep-equal": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+        "react-side-effect": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.0.2.tgz"
+      }
     },
     "react-hot-loader": {
       "version": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-3.0.0-beta.6.tgz",
       "integrity": "sha1-Rj+sC/yLY6g4UlivIMkWNqvOdfQ=",
       "dev": true,
+      "requires": {
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
+        "global": "https://registry.npmjs.org/global/-/global-4.3.1.tgz",
+        "react-deep-force-update": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-2.0.1.tgz",
+        "react-proxy": "https://registry.npmjs.org/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz",
+        "redbox-react": "https://registry.npmjs.org/redbox-react/-/redbox-react-1.3.3.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+      },
       "dependencies": {
         "source-map": {
           "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+          }
         }
       }
     },
     "react-proxy": {
       "version": "https://registry.npmjs.org/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz",
       "integrity": "sha1-RABCa8+oDKpnJMd1VpUxUgn6Swc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      }
     },
     "react-responsive-mixin": {
       "version": "https://registry.npmjs.org/react-responsive-mixin/-/react-responsive-mixin-0.4.0.tgz",
       "integrity": "sha1-lQQhihfUk0bZoJofWUX2Ka/bYks=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "can-use-dom": "https://registry.npmjs.org/can-use-dom/-/can-use-dom-0.1.0.tgz",
+        "enquire.js": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.1.tgz",
+        "json2mq": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz"
+      }
     },
     "react-scroll": {
       "version": "https://registry.npmjs.org/react-scroll/-/react-scroll-1.4.7.tgz",
-      "integrity": "sha1-4oI9CXftdtXVuf2NyOGvtD67iP4="
+      "integrity": "sha1-4oI9CXftdtXVuf2NyOGvtD67iP4=",
+      "requires": {
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+      }
     },
     "react-side-effect": {
       "version": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.0.2.tgz",
       "integrity": "sha1-mONU3s2/AoHkIj2HhS0z40XtpWE=",
+      "requires": {
+        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.1.0-alpha.10.tgz"
+      },
       "dependencies": {
         "core-js": {
           "version": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
@@ -7315,7 +11151,12 @@
         },
         "fbjs": {
           "version": "https://registry.npmjs.org/fbjs/-/fbjs-0.1.0-alpha.10.tgz",
-          "integrity": "sha1-RuRXwJy++1H8dSo+Aw57Z/zDhMg="
+          "integrity": "sha1-RuRXwJy++1H8dSo+Aw57Z/zDhMg=",
+          "requires": {
+            "core-js": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+            "promise": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
+            "whatwg-fetch": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
+          }
         },
         "whatwg-fetch": {
           "version": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
@@ -7326,32 +11167,63 @@
     "react-slick": {
       "version": "https://registry.npmjs.org/react-slick/-/react-slick-0.14.5.tgz",
       "integrity": "sha1-KeLi1zZTp4asON43nG5vJ/+gsCk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "classnames": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
+        "json2mq": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+        "react-responsive-mixin": "https://registry.npmjs.org/react-responsive-mixin/-/react-responsive-mixin-0.4.0.tgz",
+        "slick-carousel": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.6.0.tgz"
+      }
     },
     "react-tap-event-plugin": {
       "version": "https://registry.npmjs.org/react-tap-event-plugin/-/react-tap-event-plugin-2.0.1.tgz",
       "integrity": "sha1-MWvrO8ZVbinshppyk+icgmqQdNI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.8.tgz"
+      }
     },
     "read-pkg": {
       "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+        "path-type": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
+      }
     },
     "read-pkg-up": {
       "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+        "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
+      }
     },
     "readable-stream": {
       "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+      }
     },
     "readdirp": {
       "version": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+        "set-immediate-shim": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -7366,44 +11238,83 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     },
     "readline2": {
       "version": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+        "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+        "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+      }
     },
     "rechoir": {
       "version": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz"
+      }
     },
     "recompose": {
       "version": "https://registry.npmjs.org/recompose/-/recompose-0.21.2.tgz",
       "integrity": "sha1-/z+9sjl7HHfEfUUb4qY7kpXURoE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "change-emitter": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.2.tgz",
+        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.8.tgz",
+        "hoist-non-react-statics": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
+        "symbol-observable": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz"
+      }
     },
     "redbox-react": {
       "version": "https://registry.npmjs.org/redbox-react/-/redbox-react-1.3.3.tgz",
       "integrity": "sha1-Y+ycLLnGIMRuK5+FQ7SJjxt4fkE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "error-stack-parser": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+      }
     },
     "redent": {
       "version": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "indent-string": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+        "strip-indent": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+      }
     },
     "reduce-css-calc": {
       "version": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+        "math-expression-evaluator": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.14.tgz",
+        "reduce-function-call": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz"
+      }
     },
     "reduce-function-call": {
       "version": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+      }
     },
     "regenerate": {
       "version": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
@@ -7417,17 +11328,31 @@
     "regenerator-transform": {
       "version": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.8.tgz",
       "integrity": "sha1-D4i7K8A5Mt23trcxLmgHjwECbWw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz",
+        "private": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+      }
     },
     "regex-cache": {
       "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+        "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+      }
     },
     "regexpu-core": {
       "version": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "regenerate": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+        "regjsgen": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+        "regjsparser": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
+      }
     },
     "regjsgen": {
       "version": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
@@ -7438,6 +11363,9 @@
       "version": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
+      "requires": {
+        "jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+      },
       "dependencies": {
         "jsesc": {
           "version": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
@@ -7459,7 +11387,10 @@
     "repeating": {
       "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
+      }
     },
     "replace-ext": {
       "version": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
@@ -7470,6 +11401,28 @@
       "version": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
       "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
       "dev": true,
+      "requires": {
+        "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+        "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
+        "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+        "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+        "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+        "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+        "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+        "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+        "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+        "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
+        "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+        "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+      },
       "dependencies": {
         "qs": {
           "version": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
@@ -7481,7 +11434,10 @@
     "request-progress": {
       "version": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "throttleit": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz"
+      }
     },
     "require-dir": {
       "version": "0.3.2",
@@ -7507,7 +11463,11 @@
     "require-uncached": {
       "version": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caller-path": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+        "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
+      }
     },
     "requires-port": {
       "version": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -7522,7 +11482,11 @@
     "resolve-dir": {
       "version": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
       "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "expand-tilde": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+        "global-modules": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz"
+      }
     },
     "resolve-from": {
       "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
@@ -7537,12 +11501,20 @@
     "response-time": {
       "version": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
       "integrity": "sha1-/6cbq5UtYvfB1Jt0NDVfvGjf/Fo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+        "on-headers": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
+      }
     },
     "restore-cursor": {
       "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "exit-hook": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+        "onetime": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
+      }
     },
     "rev-hash": {
       "version": "https://registry.npmjs.org/rev-hash/-/rev-hash-1.0.0.tgz",
@@ -7552,7 +11524,10 @@
     "rev-path": {
       "version": "https://registry.npmjs.org/rev-path/-/rev-path-1.0.0.tgz",
       "integrity": "sha1-1My0NqwzcMRgcXXOiOr8XGXF1lM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "modify-filename": "https://registry.npmjs.org/modify-filename/-/modify-filename-1.1.0.tgz"
+      }
     },
     "rgb2hex": {
       "version": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.0.tgz",
@@ -7562,12 +11537,18 @@
     "right-align": {
       "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+      }
     },
     "rimraf": {
       "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
       "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+      }
     },
     "ripemd160": {
       "version": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
@@ -7587,12 +11568,19 @@
     "run-async": {
       "version": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+      }
     },
     "run-sequence": {
       "version": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.2.2.tgz",
       "integrity": "sha1-UJWgvr6YczsBQL0I3YDsAw3azes=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz"
+      }
     },
     "rx": {
       "version": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
@@ -7607,17 +11595,30 @@
     "sass-graph": {
       "version": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.1.2.tgz",
       "integrity": "sha1-llEEviPoEDy35fcQ32WTWzF9pXs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz"
+      }
     },
     "sass-loader": {
       "version": "https://registry.npmjs.org/sass-loader/-/sass-loader-4.1.1.tgz",
       "integrity": "sha1-ee+UaM8L9kbClSnh8sumvW5Rx7w=",
       "dev": true,
+      "requires": {
+        "async": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+      },
       "dependencies": {
         "async": {
           "version": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
           "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          }
         }
       }
     },
@@ -7630,6 +11631,19 @@
       "version": "https://registry.npmjs.org/selenium-standalone/-/selenium-standalone-5.9.0.tgz",
       "integrity": "sha1-mIyJ2pQnfluPI2cY8o6e7Mzemb0=",
       "dev": true,
+      "requires": {
+        "async": "https://registry.npmjs.org/async/-/async-1.2.1.tgz",
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+        "progress": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+        "tar-stream": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
+        "urijs": "https://registry.npmjs.org/urijs/-/urijs-1.16.1.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
+        "yauzl": "https://registry.npmjs.org/yauzl/-/yauzl-2.7.0.tgz"
+      },
       "dependencies": {
         "asn1": {
           "version": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
@@ -7654,7 +11668,10 @@
         "boom": {
           "version": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
           "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+          }
         },
         "caseless": {
           "version": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
@@ -7664,7 +11681,10 @@
         "combined-stream": {
           "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
           "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+          }
         },
         "commander": {
           "version": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
@@ -7674,7 +11694,10 @@
         "cryptiles": {
           "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
           "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "boom": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+          }
         },
         "delayed-stream": {
           "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
@@ -7690,6 +11713,11 @@
           "version": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
           "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
           "dev": true,
+          "requires": {
+            "async": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+            "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
+          },
           "dependencies": {
             "async": {
               "version": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
@@ -7699,14 +11727,23 @@
             "mime-types": {
               "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
               "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+              }
             }
           }
         },
         "hawk": {
           "version": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
           "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "boom": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+            "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+            "hoek": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+            "sntp": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+          }
         },
         "hoek": {
           "version": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
@@ -7716,12 +11753,20 @@
         "http-signature": {
           "version": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
           "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+            "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+            "ctype": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+          }
         },
         "is-absolute": {
           "version": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
           "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-relative": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+          }
         },
         "is-relative": {
           "version": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
@@ -7752,6 +11797,9 @@
           "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
           "dev": true,
+          "requires": {
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+          },
           "dependencies": {
             "minimist": {
               "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
@@ -7778,22 +11826,50 @@
         "request": {
           "version": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
           "integrity": "sha1-NdALvswBLlX5B7G9ng29V3v+8m4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+            "bl": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+            "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
+            "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+            "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+            "form-data": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+            "hawk": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+            "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+            "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+            "node-uuid": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+            "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
+            "qs": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+            "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+            "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+          }
         },
         "sntp": {
           "version": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
           "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+          }
         },
         "which": {
           "version": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
           "integrity": "sha1-nOUSRZlGFm4SwIPwjsBzOA/Iy7s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-absolute": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz"
+          }
         },
         "yauzl": {
           "version": "https://registry.npmjs.org/yauzl/-/yauzl-2.7.0.tgz",
           "integrity": "sha1-4h2EeGi0lvwp6uwj7of90z6bK84=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-crc32": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "fd-slicer": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
+          }
         }
       }
     },
@@ -7804,7 +11880,22 @@
     },
     "send": {
       "version": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
-      "integrity": "sha1-qVSYQyU5L1FTKndgdg5FlZjIn3o="
+      "integrity": "sha1-qVSYQyU5L1FTKndgdg5FlZjIn3o=",
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+        "destroy": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+        "etag": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+        "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+        "mime": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+        "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+        "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+        "range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+      }
     },
     "sequencify": {
       "version": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
@@ -7815,6 +11906,12 @@
       "version": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.2.tgz",
       "integrity": "sha1-3UGeJo3gEqtysxnTN/IQUBP5OB8=",
       "dev": true,
+      "requires": {
+        "etag": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+        "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+        "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+      },
       "dependencies": {
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
@@ -7827,16 +11924,33 @@
       "version": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz",
       "integrity": "sha1-egV/xu4o3GP2RWbl+lexEahq7NI=",
       "dev": true,
+      "requires": {
+        "accepts": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
+        "batch": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+      },
       "dependencies": {
         "accepts": {
           "version": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
           "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+            "negotiator": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+          }
         },
         "http-errors": {
           "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
           "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+          }
         },
         "negotiator": {
           "version": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
@@ -7847,7 +11961,13 @@
     },
     "serve-static": {
       "version": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
-      "integrity": "sha1-1sznaTUF9zPHWd5Xvvwa92wPCAU="
+      "integrity": "sha1-1sznaTUF9zPHWd5Xvvwa92wPCAU=",
+      "requires": {
+        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+        "send": "https://registry.npmjs.org/send/-/send-0.14.1.tgz"
+      }
     },
     "set-blocking": {
       "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -7875,12 +11995,23 @@
     "shell-quote": {
       "version": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
       "integrity": "sha1-lSxE4LHtkBPvU5WBecxkPod3Rms=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-filter": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+        "array-map": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+        "array-reduce": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+        "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+      }
     },
     "shelljs": {
       "version": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.5.tgz",
       "integrity": "sha1-Lu96UKIeHM832gDfdn7GnjCtBnU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "interpret": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
+        "rechoir": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
+      }
     },
     "sigmund": {
       "version": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
@@ -7910,17 +12041,26 @@
     "slick-carousel": {
       "version": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.6.0.tgz",
       "integrity": "sha1-eA83jkcPTm9r7BqiuuBHX0+esIU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jquery": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz"
+      }
     },
     "sntp": {
       "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+      }
     },
     "sort-keys": {
       "version": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+      }
     },
     "source-list-map": {
       "version": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.7.tgz",
@@ -7935,12 +12075,21 @@
     "source-map-resolve": {
       "version": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
       "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "atob": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+        "resolve-url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+        "source-map-url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+        "urix": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
+      }
     },
     "source-map-support": {
       "version": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.8.tgz",
       "integrity": "sha1-SHGRjYo68HKJGC6XTjKEQyey6Ys=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      }
     },
     "source-map-url": {
       "version": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
@@ -7950,7 +12099,10 @@
     "sourcemapped-stacktrace": {
       "version": "https://registry.npmjs.org/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.5.tgz",
       "integrity": "sha1-hfgIXG2rnN5xfpYevpoWt6VDS1Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      }
     },
     "sparkles": {
       "version": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
@@ -7960,12 +12112,19 @@
     "spawn-sync": {
       "version": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
       "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+        "os-shim": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
+      }
     },
     "spdx-correct": {
       "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+      }
     },
     "spdx-expression-parse": {
       "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
@@ -7979,12 +12138,18 @@
     },
     "split": {
       "version": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8="
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "requires": {
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      }
     },
     "split2": {
       "version": "https://registry.npmjs.org/split2/-/split2-2.1.1.tgz",
       "integrity": "sha1-eh9VHhdqkOzTNF9yRqDP4XXvT9A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
     },
     "sprintf-js": {
       "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -7995,6 +12160,17 @@
       "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
       "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
       "dev": true,
+      "requires": {
+        "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+        "bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+        "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+        "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+        "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+        "jodid25519": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -8016,6 +12192,10 @@
       "version": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -8025,13 +12205,25 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     },
     "stream-combiner": {
       "version": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ="
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "requires": {
+        "duplexer": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+      }
     },
     "stream-consume": {
       "version": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
@@ -8041,12 +12233,22 @@
     "stream-counter": {
       "version": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
       "integrity": "sha1-3tJmVWMZyLDiIoErnPOyb6fZR94=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+      }
     },
     "stream-http": {
       "version": "https://registry.npmjs.org/stream-http/-/stream-http-2.5.0.tgz",
       "integrity": "sha1-WF7uUTIX7Zj+GZgX5zE7b3cqaAI=",
       "dev": true,
+      "requires": {
+        "builtin-status-codes": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-2.0.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+        "to-arraybuffer": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -8056,7 +12258,16 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     },
@@ -8074,6 +12285,9 @@
       "version": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.5.tgz",
       "integrity": "sha1-h1BxEb644phFFxe1Ec/tjwAqv1M=",
       "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -8083,18 +12297,22 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     },
     "strict-uri-encode": {
       "version": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true
-    },
-    "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
     "string-convert": {
@@ -8105,6 +12323,16 @@
     "string-width": {
       "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+        "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+      }
+    },
+    "string_decoder": {
+      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
     "stringstream": {
@@ -8115,22 +12343,36 @@
     "strip-ansi": {
       "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+      }
     },
     "strip-bom": {
       "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
       "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "first-chunk-stream": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+        "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+      }
     },
     "strip-bom-stream": {
       "version": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
       "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
       "dev": true,
+      "requires": {
+        "first-chunk-stream": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+      },
       "dependencies": {
         "first-chunk-stream": {
           "version": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
           "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          }
         },
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -8140,19 +12382,34 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         },
         "strip-bom": {
           "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+          }
         }
       }
     },
     "strip-indent": {
       "version": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+      }
     },
     "strip-json-comments": {
       "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
@@ -8167,7 +12424,10 @@
     "style-loader": {
       "version": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.1.tgz",
       "integrity": "sha1-RoKA77wEcwI806bNVuM7Wh1/w6k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz"
+      }
     },
     "supports-color": {
       "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -8177,7 +12437,16 @@
     "svgo": {
       "version": "https://registry.npmjs.org/svgo/-/svgo-0.7.1.tgz",
       "integrity": "sha1-KHMg/tlyywl+csK7FoX5b+CPgDQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "coa": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
+        "colors": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+        "csso": "https://registry.npmjs.org/csso/-/csso-2.2.1.tgz",
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "sax": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+        "whet.extend": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
+      }
     },
     "symbol-observable": {
       "version": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
@@ -8188,6 +12457,14 @@
       "version": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
+      "requires": {
+        "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.10.3.tgz",
+        "ajv-keywords": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.0.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "slice-ansi": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -8197,7 +12474,11 @@
         "string-width": {
           "version": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
           "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+          }
         }
       }
     },
@@ -8209,22 +12490,39 @@
     "tar": {
       "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+        "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
     },
     "tar-stream": {
       "version": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
       "integrity": "sha1-+8bG6DwaGdTLSMfZYXH8JI7/x78=",
       "dev": true,
+      "requires": {
+        "bl": "https://registry.npmjs.org/bl/-/bl-1.2.0.tgz",
+        "end-of-stream": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      },
       "dependencies": {
         "bl": {
           "version": "https://registry.npmjs.org/bl/-/bl-1.2.0.tgz",
           "integrity": "sha1-E5fn7ELF9dw4dHDFAONKn2vp6pg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          }
         },
         "end-of-stream": {
           "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
           "integrity": "sha1-6TUyWLqpEIll78QcsO+K3i88+wc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+          }
         },
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -8234,12 +12532,24 @@
         "once": {
           "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+          }
         },
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     },
@@ -8249,20 +12559,39 @@
     },
     "tcomb-doc": {
       "version": "https://registry.npmjs.org/tcomb-doc/-/tcomb-doc-0.5.2.tgz",
-      "integrity": "sha1-1YplOjAH42SRJ4ZAEMVYp79mbR4="
+      "integrity": "sha1-1YplOjAH42SRJ4ZAEMVYp79mbR4=",
+      "requires": {
+        "tcomb": "https://registry.npmjs.org/tcomb/-/tcomb-3.2.16.tgz"
+      }
     },
     "tcomb-react": {
       "version": "https://registry.npmjs.org/tcomb-react/-/tcomb-react-0.9.3.tgz",
-      "integrity": "sha1-RHE+HS6ML/dEuO1leb93rtI7Dvw="
+      "integrity": "sha1-RHE+HS6ML/dEuO1leb93rtI7Dvw=",
+      "requires": {
+        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+        "get-comments": "https://registry.npmjs.org/get-comments/-/get-comments-1.0.1.tgz",
+        "react": "https://registry.npmjs.org/react/-/react-15.4.1.tgz",
+        "tcomb-doc": "https://registry.npmjs.org/tcomb-doc/-/tcomb-doc-0.5.2.tgz",
+        "tcomb-validation": "https://registry.npmjs.org/tcomb-validation/-/tcomb-validation-3.3.0.tgz"
+      }
     },
     "tcomb-validation": {
       "version": "https://registry.npmjs.org/tcomb-validation/-/tcomb-validation-3.3.0.tgz",
-      "integrity": "sha1-Ka2oU0IDUA6QskXu3Q4agPGQm6I="
+      "integrity": "sha1-Ka2oU0IDUA6QskXu3Q4agPGQm6I=",
+      "requires": {
+        "tcomb": "https://registry.npmjs.org/tcomb/-/tcomb-3.2.16.tgz"
+      }
     },
     "ternary-stream": {
       "version": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
       "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "duplexify": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+        "fork-stream": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
+        "merge-stream": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
     },
     "text-table": {
       "version": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -8271,7 +12600,10 @@
     },
     "thenify": {
       "version": "https://registry.npmjs.org/thenify/-/thenify-3.2.1.tgz",
-      "integrity": "sha1-JR/RyAr/blz1fLF5qx/LckJpvRE="
+      "integrity": "sha1-JR/RyAr/blz1fLF5qx/LckJpvRE=",
+      "requires": {
+        "any-promise": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz"
+      }
     },
     "throttleit": {
       "version": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
@@ -8286,6 +12618,10 @@
       "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -8295,24 +12631,44 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     },
     "through2-reduce": {
       "version": "https://registry.npmjs.org/through2-reduce/-/through2-reduce-1.1.1.tgz",
       "integrity": "sha1-QCv5qWQO//9RNpkbx9xyoqdnJRw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      }
     },
     "through2-spy": {
       "version": "https://registry.npmjs.org/through2-spy/-/through2-spy-2.0.0.tgz",
       "integrity": "sha1-m4hMPf+avYoJEjfwLE8ZGZ8/8Kg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      }
     },
     "tildify": {
       "version": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
       "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+      }
     },
     "time-stamp": {
       "version": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz",
@@ -8322,17 +12678,40 @@
     "timers-browserify": {
       "version": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
       "integrity": "sha1-q0iDz1l9zVCvIRNJoA+8pWrIa4Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "setimmediate": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+      }
     },
     "tiny-lr": {
       "version": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.2.1.tgz",
       "integrity": "sha1-s/26gC5dVqM8L28QeUsy5Hescp0=",
       "dev": true,
+      "requires": {
+        "body-parser": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "faye-websocket": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+        "livereload-js": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
+        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
+      },
       "dependencies": {
         "body-parser": {
           "version": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
           "integrity": "sha1-EBXLH+LEQ4WCWVgdtTMy+NDPUPk=",
           "dev": true,
+          "requires": {
+            "bytes": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
+            "content-type": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+            "depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+            "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+            "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+            "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "qs": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+            "raw-body": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+            "type-is": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz"
+          },
           "dependencies": {
             "qs": {
               "version": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
@@ -8349,7 +12728,11 @@
         "http-errors": {
           "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
           "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+          }
         },
         "iconv-lite": {
           "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
@@ -8366,7 +12749,10 @@
     "tmp": {
       "version": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
       "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+      }
     },
     "to-arraybuffer": {
       "version": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
@@ -8381,7 +12767,10 @@
     "tough-cookie": {
       "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+      }
     },
     "trim-newlines": {
       "version": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -8417,11 +12806,18 @@
     "type-check": {
       "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+      }
     },
     "type-is": {
       "version": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
-      "integrity": "sha1-4hljnBfe0coHiQkt1UoDgmuBfLI="
+      "integrity": "sha1-4hljnBfe0coHiQkt1UoDgmuBfLI=",
+      "requires": {
+        "media-typer": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz"
+      }
     },
     "typedarray": {
       "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -8436,6 +12832,12 @@
       "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
       "integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
       "dev": true,
+      "requires": {
+        "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+        "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+      },
       "dependencies": {
         "async": {
           "version": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
@@ -8450,7 +12852,12 @@
         "cliui": {
           "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+          }
         },
         "window-size": {
           "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
@@ -8465,7 +12872,13 @@
         "yargs": {
           "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+            "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+          }
         }
       }
     },
@@ -8477,7 +12890,11 @@
     "uid-safe": {
       "version": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.3.tgz",
       "integrity": "sha1-B34mSgCzGHk2snC7c3aiZHNjEHE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "base64-url": "https://registry.npmjs.org/base64-url/-/base64-url-1.3.3.tgz",
+        "random-bytes": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz"
+      }
     },
     "unc-path-regex": {
       "version": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
@@ -8492,7 +12909,10 @@
     "uniqid": {
       "version": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.0.tgz",
       "integrity": "sha1-M9lnn2UCL0iYigP9JOfcr48Qnso=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "macaddress": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz"
+      }
     },
     "uniqs": {
       "version": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
@@ -8522,6 +12942,10 @@
       "version": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
+      "requires": {
+        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+        "querystring": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+      },
       "dependencies": {
         "punycode": {
           "version": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -8538,6 +12962,10 @@
       "version": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.7.tgz",
       "integrity": "sha1-Z+h3l1n4AA2nSZSQZoDJQ6mwkl0=",
       "dev": true,
+      "requires": {
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
+        "mime": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+      },
       "dependencies": {
         "mime": {
           "version": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
@@ -8555,6 +12983,9 @@
       "version": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+      },
       "dependencies": {
         "inherits": {
           "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
@@ -8580,12 +13011,19 @@
     "v8flags": {
       "version": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
       "integrity": "sha1-vKjzDw1tYGEswsAGQeaWLUKuaIE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "user-home": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+      }
     },
     "validate-npm-package-license": {
       "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+        "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+      }
     },
     "validator": {
       "version": "https://registry.npmjs.org/validator/-/validator-5.7.0.tgz",
@@ -8604,7 +13042,10 @@
     "verror": {
       "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+      }
     },
     "vhost": {
       "version": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz",
@@ -8614,12 +13055,25 @@
     "vinyl": {
       "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+        "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+        "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+      }
     },
     "vinyl-file": {
       "version": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
       "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+        "strip-bom-stream": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -8629,12 +13083,20 @@
         "strip-bom": {
           "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+          }
         },
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+          }
         }
       }
     },
@@ -8642,6 +13104,16 @@
       "version": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
       "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
       "dev": true,
+      "requires": {
+        "defaults": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+        "glob-stream": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+        "glob-watcher": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+      },
       "dependencies": {
         "clone": {
           "version": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
@@ -8651,39 +13123,67 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
         },
         "through2": {
           "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          }
         },
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+          }
         }
       }
     },
     "vinyl-sourcemaps-apply": {
       "version": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
       "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      }
     },
     "vm-browserify": {
       "version": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "indexof": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+      }
     },
     "warning": {
       "version": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
       "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz"
+      }
     },
     "watchpack": {
       "version": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
       "integrity": "sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws=",
       "dev": true,
+      "requires": {
+        "async": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+        "chokidar": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+      },
       "dependencies": {
         "async": {
           "version": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
@@ -8701,11 +13201,17 @@
       "version": "https://registry.npmjs.org/wdio-dot-reporter/-/wdio-dot-reporter-0.0.6.tgz",
       "integrity": "sha1-FTs+HF12d3GQ2JNID/pvN4M3QPE=",
       "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz"
+      },
       "dependencies": {
         "babel-runtime": {
           "version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
           "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-js": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
+          }
         },
         "core-js": {
           "version": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
@@ -8718,26 +13224,75 @@
       "version": "https://registry.npmjs.org/webdriverio/-/webdriverio-4.5.2.tgz",
       "integrity": "sha1-kyHAmdIYIHTz/1mEFWYzRGoiQG0=",
       "dev": true,
+      "requires": {
+        "archiver": "https://registry.npmjs.org/archiver/-/archiver-1.0.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+        "css-parse": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz",
+        "css-value": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
+        "deepmerge": "https://registry.npmjs.org/deepmerge/-/deepmerge-0.2.10.tgz",
+        "ejs": "https://registry.npmjs.org/ejs/-/ejs-2.5.5.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "npm-install-package": "https://registry.npmjs.org/npm-install-package/-/npm-install-package-1.1.0.tgz",
+        "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+        "q": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+        "rgb2hex": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.0.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+        "url": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+        "validator": "https://registry.npmjs.org/validator/-/validator-5.7.0.tgz",
+        "wdio-dot-reporter": "https://registry.npmjs.org/wdio-dot-reporter/-/wdio-dot-reporter-0.0.6.tgz",
+        "wgxpath": "https://registry.npmjs.org/wgxpath/-/wgxpath-1.0.0.tgz"
+      },
       "dependencies": {
         "async": {
           "version": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
           "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          }
         },
         "bl": {
           "version": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
           "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+          }
         },
         "form-data": {
           "version": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
           "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "async": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
+            "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz"
+          }
         },
         "inquirer": {
           "version": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
           "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "cli-cursor": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+            "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+            "external-editor": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+            "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
+            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "run-async": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+            "rx": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+          }
         },
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -8762,22 +13317,59 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         },
         "request": {
           "version": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
           "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+            "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
+            "bl": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+            "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+            "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+            "extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+            "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "form-data": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+            "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+            "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+            "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+            "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+            "node-uuid": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+            "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "qs": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+            "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+            "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+          }
         },
         "run-async": {
           "version": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
           "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-promise": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
+          }
         },
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
         }
       }
     },
@@ -8785,6 +13377,23 @@
       "version": "https://registry.npmjs.org/webpack/-/webpack-1.14.0.tgz",
       "integrity": "sha1-VPH/uSBRoyilsgV9auM8KJRiyCM=",
       "dev": true,
+      "requires": {
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+        "enhanced-resolve": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+        "interpret": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
+        "memory-fs": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "node-libs-browser": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz",
+        "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+        "tapable": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+        "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
+        "watchpack": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
+        "webpack-core": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz"
+      },
       "dependencies": {
         "interpret": {
           "version": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
@@ -8799,17 +13408,33 @@
         "memory-fs": {
           "version": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
           "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "errno": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          }
         },
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         },
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
         }
       }
     },
@@ -8817,33 +13442,65 @@
       "version": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
       "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
       "dev": true,
+      "requires": {
+        "source-list-map": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.7.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+      },
       "dependencies": {
         "source-map": {
           "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+          }
         }
       }
     },
     "webpack-dev-middleware": {
       "version": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.9.0.tgz",
       "integrity": "sha1-ocZ6Pf2KXF1idAqgur5hdYtMhKo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "memory-fs": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+        "mime": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+        "range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+      }
     },
     "webpack-hot-middleware": {
       "version": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.15.0.tgz",
       "integrity": "sha1-cZla98ACXxCd9IL4bx4QN5Um0CY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-html": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.6.tgz",
+        "html-entities": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.0.tgz",
+        "querystring": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+      }
     },
     "webpack-sources": {
       "version": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.3.tgz",
       "integrity": "sha1-Fc4vt50KHacnREunx1e/FkKU8xA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "source-list-map": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.7.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      }
     },
     "webpack-stream": {
       "version": "https://registry.npmjs.org/webpack-stream/-/webpack-stream-3.2.0.tgz",
       "integrity": "sha1-Oh0WD7EdQXJ7fObzL3IkZPmLIYY=",
       "dev": true,
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "lodash.clone": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+        "lodash.some": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+        "memory-fs": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+        "webpack": "https://registry.npmjs.org/webpack/-/webpack-1.14.0.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -8853,24 +13510,45 @@
         "memory-fs": {
           "version": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
           "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "errno": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          }
         },
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         },
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+          }
         }
       }
     },
     "websocket-driver": {
       "version": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
       "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "websocket-extensions": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+      }
     },
     "websocket-extensions": {
       "version": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
@@ -8899,7 +13577,10 @@
     "which": {
       "version": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
       "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isexe": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+      }
     },
     "which-module": {
       "version": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
@@ -8909,7 +13590,10 @@
     "wide-align": {
       "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
       "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+      }
     },
     "window-size": {
       "version": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
@@ -8924,7 +13608,11 @@
     "wrap-ansi": {
       "version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+      }
     },
     "wrappy": {
       "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -8934,7 +13622,10 @@
     "write": {
       "version": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+      }
     },
     "xtend": {
       "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
@@ -8954,12 +13645,32 @@
     "yargs": {
       "version": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
       "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+        "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+        "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+        "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+        "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+        "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+        "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+        "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+        "which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+        "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+        "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+        "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz"
+      }
     },
     "yargs-parser": {
       "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
       "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
       "dev": true,
+      "requires": {
+        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+        "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
+      },
       "dependencies": {
         "camelcase": {
           "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
@@ -8971,12 +13682,21 @@
     "yauzl": {
       "version": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fd-slicer": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
+      }
     },
     "zip-stream": {
       "version": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.1.0.tgz",
       "integrity": "sha1-KtR5//wWjgWoiOjDSP9oE7PxNzM=",
       "dev": true,
+      "requires": {
+        "archiver-utils": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+        "compress-commons": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.1.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -8986,7 +13706,16 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         }
       }
     }

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "isomorphic-fetch": "^2.2.1",
     "lodash.camelcase": "^4.1.0",
     "lodash.debounce": "^4.0.3",
+    "mixpanel-browser": "^2.22.0",
     "react-autosize-textarea": "^0.3.4",
     "react-helmet": "^3.1.0",
     "react-scroll": "^1.4.7",


### PR DESCRIPTION
* Adds optional analytics collection to Postfacto.

* Allows Postfacto team to learn from how people are using Postfacto.

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the API unit tests using `bundle exec rake` from the `/api` submodule.

* [x] I have run all the WEB unit tests using `gulp spec-app` from the `/web` submodule.

* [x] I have run all the acceptance tests using `gulp local-acceptance` from the `/web` submodule.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added
